### PR TITLE
Permissions are retrieved from app_metadata

### DIFF
--- a/lib/mumukit/auth/token.rb
+++ b/lib/mumukit/auth/token.rb
@@ -13,7 +13,7 @@ module Mumukit::Auth
     end
 
     def permissions(app)
-      jwt.dig('user_metadata', app, 'permissions').to_mumukit_auth_permissions
+      jwt.dig('app_metadata', app, 'permissions').to_mumukit_auth_permissions
     end
 
     def self.decode_header(header)

--- a/spec/mumukit/token_spec.rb
+++ b/spec/mumukit/token_spec.rb
@@ -20,13 +20,15 @@ describe Mumukit::Auth::Token do
   describe 'permissions' do
     let(:token) { Mumukit::Auth::Token.new(jwt) }
     context 'when metadata' do
-      let(:jwt) { {'user_metadata' => {'myapp' => {'permissions' => '*'}}} }
+      let(:jwt) { {'app_metadata' => {'myapp' => {'permissions' => '*'}}} }
+      let(:permissions) { token.permissions 'myapp' }
 
-      it { expect(token.permissions 'myapp').to be_instance_of(Mumukit::Auth::Permissions) }
+      it { expect(permissions).to be_instance_of(Mumukit::Auth::Permissions) }
+      it { expect(permissions.allows? 'pdep-utn/mumuki-guia-funcional-introduccion').to eq true }
     end
 
     context 'when empty metadata' do
-      let(:jwt) { {'user_metadata' => {}} }
+      let(:jwt) { {'app_metadata' => {}} }
       it { expect(token.permissions 'myapp').to be_instance_of(Mumukit::Auth::Permissions) }
     end
 


### PR DESCRIPTION
As stated in [auth0 docs](https://auth0.com/docs/user-profile#structure-of-user-profile-data), that is the right field to store read-only information.
