### PR TITLE
Feature #29 case insensitive slugs

### DIFF
--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -59,7 +59,7 @@ module Mumukit::Auth
 
   class FirstPartGrant < Grant
     def initialize(first)
-      @first = first
+      @first = first.downcase
     end
 
     def allows?(resource_slug)

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -15,8 +15,8 @@ module Mumukit::Auth
     alias_method :content, :second
 
     def initialize(first, second)
-      @first = first
-      @second = second
+      @first = first.downcase
+      @second = second.downcase
     end
 
     def match_first(first)

--- a/spec/mumukit/grant_spec.rb
+++ b/spec/mumukit/grant_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 describe Mumukit::Auth::Grant do
+  describe 'to_s' do
+    it { expect('Foo/*'.to_mumukit_grant.to_s).to eq  'foo/*' }
+    it { expect('*'.to_mumukit_grant.to_s).to eq  '*' }
+    it { expect('Foo/Bar'.to_mumukit_grant.to_s).to eq  'foo/bar' }
+  end
+
   describe 'compare' do
     it { expect('foo/baz'.to_mumukit_grant).to eq  'foo/baz'.to_mumukit_grant }
     it { expect('FOO/BAZ'.to_mumukit_grant).to eq  'foo/baz'.to_mumukit_grant }

--- a/spec/mumukit/grant_spec.rb
+++ b/spec/mumukit/grant_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 
 describe Mumukit::Auth::Grant do
   describe 'compare' do
+    it { expect('foo/baz'.to_mumukit_grant).to eq  'foo/baz'.to_mumukit_grant }
+    it { expect('FOO/BAZ'.to_mumukit_grant).to eq  'foo/baz'.to_mumukit_grant }
+    it { expect('Foo/Baz'.to_mumukit_grant).to eq  'FOO/BAZ'.to_mumukit_grant }
+    it { expect('Foo/*'.to_mumukit_grant).to eq  'FOO/*'.to_mumukit_grant }
+
     it { expect('*'.to_mumukit_grant == '*'.to_mumukit_grant).to be true }
     it { expect('*'.to_mumukit_grant.eql? '*'.to_mumukit_grant).to be true }
     it { expect('*'.to_mumukit_grant.hash == '*'.to_mumukit_grant.hash).to be true }
@@ -27,6 +32,7 @@ describe Mumukit::Auth::Grant do
     it { expect(grant.allows? 'foo/_').to be true }
 
     it { expect(grant.allows? 'foo/bar').to be true }
+    it { expect(grant.allows? 'Foo/Bar').to be true }
 
   end
 
@@ -37,6 +43,7 @@ describe Mumukit::Auth::Grant do
 
     it { expect(grant.allows? 'foo/_').to be true }
     it { expect(grant.allows? 'foo/bar').to be true }
+    it { expect(grant.allows? 'FOO/BAR').to be true }
 
     it { expect(grant.to_s).to eq '*' }
   end
@@ -47,6 +54,7 @@ describe Mumukit::Auth::Grant do
     it { expect(grant.allows? '_/_').to be true }
 
     it { expect(grant.allows? 'foo/_').to be true }
+    it { expect(grant.allows? 'FOO/Bar').to be true }
 
     it { expect(grant.allows? 'fooz/_').to be false }
     it { expect(grant.allows? 'xfoo/_').to be false }
@@ -70,6 +78,9 @@ describe Mumukit::Auth::Grant do
     it { expect(grant.allows? 'foo/bag').to be false }
     it { expect(grant.allows? 'foo/bar').to be true }
     it { expect(grant.allows? 'fooz/baz').to be false }
+
+    it { expect(grant.allows? 'FOO/BAR').to be true }
+    it { expect(Mumukit::Auth::Grant.parse('FOO/Bar').allows? 'foo/BAR').to be true }
   end
 
 end

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -142,7 +142,7 @@ describe Mumukit::Auth::Permissions do
     it { expect(Mumukit::Auth::Permissions.parse(student: 'foo/bar:baz/goo').grant_strings_for :student).to eq ['foo/bar', 'baz/goo'] }
   end
 
-  describe 'add_scope!' do
+  describe 'add_permission!' do
     let(:permissions) { parse_permissions({}) }
     context 'when no teacher permissions added' do
       before { permissions.add_permission!(:teacher, 'test/bar') }
@@ -153,6 +153,7 @@ describe Mumukit::Auth::Permissions do
       it { expect(permissions.teacher? 'test/bar').to eq true }
 
       it { expect(permissions.has_permission? :teacher, 'test/bar').to be true }
+      it { expect(permissions.has_permission? :teacher, 'Test/Bar').to be true }
       it { expect(permissions.has_permission? :teacher, 'test/baz').to be false }
 
       it { expect(permissions.as_json).to json_like(teacher: 'test/bar') }
@@ -164,7 +165,14 @@ describe Mumukit::Auth::Permissions do
         it { expect(permissions.has_permission? :teacher, 'test/baz').to be true }
       end
 
+      context 'when added broader grant with upcase' do
+        before { permissions.add_permission! :teacher, 'Test/*' }
+
+        it { expect(permissions).to json_like teacher: 'test/*' }
+        it { expect(permissions.has_permission? :teacher, 'test/baz').to be true }
+      end
     end
+
     context 'when no student permissions added' do
       before { permissions.add_permission!(:student, 'test/*') }
 
@@ -240,6 +248,7 @@ describe Mumukit::Auth::Permissions do
     it { expect(permissions.headmaster? 'foo/baz').to eq true }
     it { expect(permissions.headmaster? 'bar/baz').to eq false }
     it { expect(permissions.headmaster? 'test/baz').to eq true }
+    it { expect(permissions.headmaster? 'Test/baz').to eq true }
     it { expect(permissions.owner? 'test/baz').to eq true }
 
   end

--- a/spec/mumukit/scope_spec.rb
+++ b/spec/mumukit/scope_spec.rb
@@ -16,6 +16,7 @@ describe Mumukit::Auth::Scope do
     it { expect(scope.allows? 'xfoo/baz').to be false }
     it { expect(scope.allows? 'mumuki/funcional').to be true }
     it { expect(scope.allows? 'mumuki/logico').to be true }
+    it { expect(scope.allows? 'Mumuki/Logico').to be true }
   end
 
   describe 'grant none' do

--- a/spec/mumukit/slug_spec.rb
+++ b/spec/mumukit/slug_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe Mumukit::Auth::Slug do
+  it { expect('foo/baz'.to_mumukit_slug).to eq  'foo/baz'.to_mumukit_slug }
+  it { expect('FOO/BAZ'.to_mumukit_slug).to eq  'foo/baz'.to_mumukit_slug }
+  it { expect('Foo/Baz'.to_mumukit_slug).to eq  'FOO/BAZ'.to_mumukit_slug }
 
   it { expect('foo/baz'.to_mumukit_slug.rebase('bar')).to eq  'bar/baz'.to_mumukit_slug }
 


### PR DESCRIPTION
Fixes #29 

Making permissions, slugs, scopes and grants case-insensitive. 