### PR TITLE
Introducing normalization methods

### DIFF
--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -63,7 +63,7 @@ module Mumukit::Auth
     end
 
     def allows?(resource_slug)
-      resource_slug.to_mumukit_slug.match_first @first
+      resource_slug.to_mumukit_slug.normalize!.match_first @first
     end
 
     def to_s
@@ -77,16 +77,16 @@ module Mumukit::Auth
 
   class SingleGrant < Grant
     def initialize(slug)
-      @slug = slug
+      @slug = slug.normalize
     end
 
     def allows?(resource_slug)
-      resource_slug = resource_slug.to_mumukit_slug
+      resource_slug = resource_slug.to_mumukit_slug.normalize!
       resource_slug.match_first(@slug.first) && resource_slug.match_second(@slug.second)
     end
 
     def to_s
-      @slug.to_case_insensitive_s
+      @slug.to_s
     end
 
     def to_mumukit_slug

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -59,7 +59,7 @@ module Mumukit::Auth
 
   class FirstPartGrant < Grant
     def initialize(first)
-      @first = first.downcase
+      @first = first.parameterize
     end
 
     def allows?(resource_slug)

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -51,8 +51,8 @@ module Mumukit::Auth
     end
 
     def normalize!
-      @first = @first.downcase
-      @second = @second.downcase
+      @first = @first.parameterize
+      @second = @second.parameterize
       self
     end
 

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -23,11 +23,11 @@ module Mumukit::Auth
     end
 
     def match_first(first)
-      match self.first.downcase, first.downcase
+      match self.first, first
     end
 
     def match_second(second)
-      match self.second.downcase, second.downcase
+      match self.second, second
     end
 
     def rebase(new_organizaton)
@@ -35,21 +35,29 @@ module Mumukit::Auth
     end
 
     def ==(o)
-      self.class == o.class && to_case_insensitive_s == o.to_case_insensitive_s
+      self.class == o.class && self.normalize.eql?(o.normalize)
     end
 
-    alias_method :eql?, :==
+    def eql?(o)
+      self.class == o.class && to_s == o.to_s
+    end
 
     def hash
-      to_case_insensitive_s.hash
+      to_s.hash
     end
 
     def to_s
       "#{first}/#{second}"
     end
 
-    def to_case_insensitive_s
-      @case_insensitive_s ||= to_s.downcase
+    def normalize!
+      @first = @first.downcase
+      @second = @second.downcase
+      self
+    end
+
+    def normalize
+      dup.normalize!
     end
 
     def inspect
@@ -88,6 +96,10 @@ module Mumukit::Auth
 
     def self.any
       parse '_/_'
+    end
+
+    def self.normalize(first, second)
+      new(first, second).normalize!
     end
 
     private

--- a/spec/mumukit/slug_spec.rb
+++ b/spec/mumukit/slug_spec.rb
@@ -1,9 +1,15 @@
 require 'spec_helper'
 
 describe Mumukit::Auth::Slug do
+  it { expect('Foo/Baz'.to_mumukit_slug.normalize).to eql  'foo/baz'.to_mumukit_slug }
+
   it { expect('foo/baz'.to_mumukit_slug).to eq  'foo/baz'.to_mumukit_slug }
   it { expect('FOO/BAZ'.to_mumukit_slug).to eq  'foo/baz'.to_mumukit_slug }
   it { expect('Foo/Baz'.to_mumukit_slug).to eq  'FOO/BAZ'.to_mumukit_slug }
+
+  it { expect('foo/baz'.to_mumukit_slug).to eql  'foo/baz'.to_mumukit_slug }
+  it { expect('FOO/BAZ'.to_mumukit_slug).to_not eql 'foo/baz'.to_mumukit_slug }
+  it { expect('Foo/Baz'.to_mumukit_slug).to_not eql 'FOO/BAZ'.to_mumukit_slug }
 
   it { expect('foo/baz'.to_mumukit_slug.rebase('bar')).to eq  'bar/baz'.to_mumukit_slug }
 
@@ -30,4 +36,7 @@ describe Mumukit::Auth::Slug do
 
   it { expect { Mumukit::Auth::Slug.join('foo', 'bar', 'baz') }.to raise_error 'Slugs must have up to two parts' }
   it { expect { Mumukit::Auth::Slug.parse('baz') }.to raise_error 'Invalid slug: baz. It must be in first/second format' }
+
+  it { expect(Mumukit::Auth::Slug.normalize('foo', 'bar').to_s).to eq 'foo/bar' }
+  it { expect(Mumukit::Auth::Slug.normalize('Foo', 'Bar').to_s).to eq 'foo/bar' }
 end

--- a/spec/mumukit/slug_spec.rb
+++ b/spec/mumukit/slug_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe Mumukit::Auth::Slug do
   it { expect('Foo/Baz'.to_mumukit_slug.normalize).to eql  'foo/baz'.to_mumukit_slug }
+  it { expect('foo/bar--baz'.to_mumukit_slug.normalize).to eql  'foo/bar-baz'.to_mumukit_slug }
+  it { expect('ein Bär/in München'.to_mumukit_slug.normalize).to eql  'ein-bar/in-munchen'.to_mumukit_slug }
 
   it { expect('foo/baz'.to_mumukit_slug).to eq  'foo/baz'.to_mumukit_slug }
   it { expect('FOO/BAZ'.to_mumukit_slug).to eq  'foo/baz'.to_mumukit_slug }


### PR DESCRIPTION
* Introducing normalization methods
* changing `eql?` and `hash` to honor case
* keeping normalized behavior in `==`

This PR continues the refactor started in 3f4eeb6d37234f531ea1185998a9236af11de8db and https://github.com/mumuki/mumukit-auth/pull/30. 

Related to https://github.com/mumuki/mumuki-bibliotheca-api/issues/86