### PR TITLE
Feature custom grant types

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ some_permissions.remove_permission! :student, 'foo/bar'
 some_permissions.update_permission! :student, 'foo/*', 'foo/bar'
 
 # Checking permissions
-some_permissions.has_permission? :student, 'foo/_'
+some_permissions.authorizes? :student, 'foo/_'
 some_permissions.student? 'foo/_' # equivalent to previous line
 some_permissions.protect! :student, 'foo/_' # similar to previous samples,
                                             # but raises and exception instead

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ a_grant.to_s
 
 Grants can be extend, by inheriting from `Mumukit::Auth::Grant::Base`, and defining the following method:
 
-* `#allows?(resource_slug)`
-* `#to_s`
-* `#to_mumukit_slug`
-* `.try_parse(pattern)`
+* `#allows?(resource_slug)`: mandatory
+* `#to_s`: mandatory
+* `#granted_organizations`: optional
+* `.try_parse(pattern)`: mandatory
 
 New grant types must be registered using: `Mumukit::Auth::Grant.add_custom_grant_type!`
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ a_grant.to_s
 
 #### Defining custom Grants
 
-Grants can be extend, by inheriting from `Mumukit::Auth::Grant::Base`, and defining the following method:
+Grants can be extended, by inheriting from `Mumukit::Auth::Grant::Base`, and defining the following method:
 
 * `#allows?(resource_slug)`: mandatory
 * `#to_s`: mandatory

--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ a_grant.to_s
 "baz/bar".to_mumukit_grant.allows? Mumukit::Auth::Slug.join('foo') # false
 ```
 
+#### Defining custom Grants
+
+Grants can be extend, by inheriting from `Mumukit::Auth::Grant::Base`, and defining the following method:
+
+* `#allows?(resource_slug)`
+* `#to_s`
+* `#to_mumukit_slug`
+* `.try_parse(pattern)`
+
+New grant types must be registered using: `Mumukit::Auth::Grant.add_custom_grant_type!`
+
 ### Roles
 
 ```ruby

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -36,6 +36,10 @@ module Mumukit::Auth::Grant
       self
     end
 
+    def granted_organizations
+      []
+    end
+
     def ==(other)
       other.class == self.class && to_s == other.to_s
     end
@@ -80,6 +84,10 @@ module Mumukit::Auth::Grant
       @first = first.downcase
     end
 
+    def granted_organizations
+      [first]
+    end
+
     def allows?(resource_slug)
       resource_slug.to_mumukit_slug.normalize!.match_first @first
     end
@@ -110,6 +118,10 @@ module Mumukit::Auth::Grant
 
     def initialize(slug)
       @slug = slug.normalize
+    end
+
+    def granted_organizations
+      [slug.first]
     end
 
     def allows?(resource_slug)

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -144,6 +144,8 @@ module Mumukit::Auth::Grant
     attr_accessor :slug
 
     def initialize(slug)
+      raise Mumukit::Auth::InvalidGrantFormatError, "Invalid slug grant. First part must not be _" if  slug.first == '_'
+      raise Mumukit::Auth::InvalidGrantFormatError, "Invalid slug grant. Second part must not be _" if  slug.second == '_'
       @slug = slug.normalize
     end
 
@@ -162,6 +164,13 @@ module Mumukit::Auth::Grant
 
     def self.try_parse(pattern)
       new(Mumukit::Auth::Slug.parse pattern)
+    rescue Mumukit::Auth::InvalidSlugFormatError => e
+        raise Mumukit::Auth::InvalidGrantFormatError, "Invalid slug grant. Cause: #{e}"
     end
+  end
+end
+
+module Mumukit::Auth
+  class InvalidGrantFormatError < StandardError
   end
 end

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -74,7 +74,11 @@ module Mumukit::Auth::Grant
 
     # tells whether the given grant-like object is included
     # in - that is, is not broader than - this grant
-    required :includes?
+    #
+    # :warning: Custom grants **should not** override this method
+    def includes?(grant_like)
+      self == grant_like.to_mumukit_grant
+    end
   end
 
   class AllGrant < Base
@@ -142,11 +146,6 @@ module Mumukit::Auth::Grant
     def allows?(slug_like)
       slug = slug_like.to_mumukit_slug.normalize!
       slug.match_first(@slug.first) && slug.match_second(@slug.second)
-    end
-
-    def includes?(grant_like)
-      grant = grant_like.to_mumukit_grant
-      grant.is_a?(SingleGrant) && grant.slug == slug
     end
 
     def to_s

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -54,9 +54,27 @@ module Mumukit::Auth::Grant
       "<Mumukit::Auth::Grant #{to_s}>"
     end
 
-    def allowed_by?(grant)
+    # Tells wether the given grant
+    # is authorized by this grant
+    #
+    # This method exist in order to implement double dispatching
+    # for both grant and slugs authorization
+    #
+    # See:
+    #  * `Mumukit::Auth::Slug#authorized_by?`
+    #  * `Mumukit::Auth::Grant::Base#allows?
+    #  * `Mumukit::Auth::Grant::Base#includes?`
+    def authorized_by?(grant)
       grant.includes? self
     end
+
+    # tells whether the given slug is allowed by
+    # this grant
+    required :allows?
+
+    # tells whether the given grant is included in - that is, is not broader than -
+    # this grant
+    required :includes?
   end
 
   class AllGrant < Base

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -53,6 +53,10 @@ module Mumukit::Auth::Grant
     def inspect
       "<Mumukit::Auth::Grant #{to_s}>"
     end
+
+    def allowed_by?(grant)
+      grant.includes? self
+    end
   end
 
   class AllGrant < Base

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -5,6 +5,19 @@ class String
 end
 
 module Mumukit::Auth::Grant
+
+  # Parses a given string that describes a grant
+  # by trying with each grant type, in the following order:
+  #
+  # 1. All grant
+  # 2. Custom grants
+  # 3. First Grant
+  # 4. Slug grant
+  #
+  # Raises a `Mumukit::Auth::InvalidGrantFormatError` if the grant is not valid, which happens when
+  #
+  # * structure is invalid
+  # * `something/_`, `_/something`, `_/_` format is used
   def self.parse(pattern)
     grant_types.each do |type|
       type.try_parse(pattern).try { |it| return it }
@@ -12,7 +25,7 @@ module Mumukit::Auth::Grant
   end
 
   def self.grant_types
-    custom_grant_types + [AllGrant, FirstPartGrant, SingleGrant]
+    [AllGrant] + custom_grant_types + [FirstPartGrant, SingleGrant]
   end
 
   def self.add_custom_grant_type!(grant_type)

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -68,17 +68,17 @@ module Mumukit::Auth::Grant
       grant.includes? self
     end
 
-    # tells whether the given slug is allowed by
+    # tells whether the given slug-like object is allowed by
     # this grant
     required :allows?
 
-    # tells whether the given grant is included in - that is, is not broader than -
-    # this grant
+    # tells whether the given grant-like object is included
+    # in - that is, is not broader than - this grant
     required :includes?
   end
 
   class AllGrant < Base
-    def allows?(_resource_slug)
+    def allows?(_slug_like)
       true
     end
 
@@ -106,18 +106,19 @@ module Mumukit::Auth::Grant
       [first]
     end
 
-    def allows?(resource_slug)
-      resource_slug.to_mumukit_slug.normalize!.match_first @first
+    def allows?(slug_like)
+      slug_like.to_mumukit_slug.normalize!.match_first @first
     end
 
     def to_s
       "#{@first}/*"
     end
 
-    def includes?(other)
-      case other
-      when FirstPartGrant then other.first == first
-      when SingleGrant then other.slug.first == first
+    def includes?(grant_like)
+      grant = grant_like.to_mumukit_grant
+      case grant
+      when FirstPartGrant then grant.first == first
+      when SingleGrant then grant.slug.first == first
       else false
       end
     end
@@ -138,13 +139,14 @@ module Mumukit::Auth::Grant
       [slug.first]
     end
 
-    def allows?(resource_slug)
-      resource_slug = resource_slug.to_mumukit_slug.normalize!
-      resource_slug.match_first(@slug.first) && resource_slug.match_second(@slug.second)
+    def allows?(slug_like)
+      slug = slug_like.to_mumukit_slug.normalize!
+      slug.match_first(@slug.first) && slug.match_second(@slug.second)
     end
 
-    def includes?(other)
-      other.is_a?(SingleGrant) && other.slug == slug
+    def includes?(grant_like)
+      grant = grant_like.to_mumukit_grant
+      grant.is_a?(SingleGrant) && grant.slug == slug
     end
 
     def to_s

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -111,6 +111,7 @@ module Mumukit::Auth::Grant
     attr_accessor :first
 
     def initialize(first)
+      raise Mumukit::Auth::InvalidGrantFormatError, "Invalid first grant. First part must not be _" if  first == '_'
       @first = first.downcase
     end
 
@@ -136,7 +137,7 @@ module Mumukit::Auth::Grant
     end
 
     def self.try_parse(pattern)
-      new($1) if pattern =~ /(.*)\/\*/
+      new($1) if pattern =~ /(.+)\/\*/
     end
   end
 

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -72,10 +72,6 @@ module Mumukit::Auth::Grant
       '*'
     end
 
-    def to_mumukit_slug
-      Mumukit::Auth::Slug.new '*', '*'
-    end
-
     def self.try_parse(pattern)
       new if ['*', '*/*'].include? pattern
     end
@@ -98,10 +94,6 @@ module Mumukit::Auth::Grant
 
     def to_s
       "#{@first}/*"
-    end
-
-    def to_mumukit_slug
-      Mumukit::Auth::Slug.new @first, '*'
     end
 
     def includes?(other)
@@ -139,10 +131,6 @@ module Mumukit::Auth::Grant
 
     def to_s
       @slug.to_s
-    end
-
-    def to_mumukit_slug
-      @slug
     end
 
     def self.try_parse(pattern)

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -71,7 +71,7 @@ module Mumukit::Auth::Grant
       "<Mumukit::Auth::Grant #{to_s}>"
     end
 
-    # Tells wether the given grant
+    # Tells whether the given grant
     # is authorized by this grant
     #
     # This method exist in order to implement double dispatching

--- a/lib/mumukit/auth/grant.rb
+++ b/lib/mumukit/auth/grant.rb
@@ -36,6 +36,10 @@ module Mumukit::Auth::Grant
       self
     end
 
+    # returns the organizations that are explicitly
+    # granted by this grant
+    #
+    # Custom grants may override this method
     def granted_organizations
       []
     end
@@ -79,6 +83,10 @@ module Mumukit::Auth::Grant
     def includes?(grant_like)
       self == grant_like.to_mumukit_grant
     end
+
+    # Returns a canonical string representation of this grant
+    # Equivalent grant **must** have equivalent string representations
+    required :to_s
   end
 
   class AllGrant < Base

--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -13,11 +13,11 @@ class Mumukit::Auth::Permissions
   end
 
   def has_permission?(role, authorizable)
-    Mumukit::Auth::Role.parse(role).allows?(authorizable, self)
+    Mumukit::Auth::Role.parse(role).authorizes?(authorizable, self)
   end
 
-  def role_allows?(role, authorizable)
-    scope_for(role).allows?(authorizable)
+  def role_authorizes?(role, authorizable)
+    scope_for(role).authorizes?(authorizable)
   end
 
   def has_role?(role)

--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -26,7 +26,7 @@ class Mumukit::Auth::Permissions
     end
   end
 
-  # tells wether this permissions
+  # tells whether this permissions
   # authorize the given authorizable object for the given role,
   # or any of its parent roles.
   def authorizes?(role, authorizable)
@@ -38,7 +38,7 @@ class Mumukit::Auth::Permissions
     authorizes? role, slug_like.to_mumukit_slug
   end
 
-  # tells wether this permissions
+  # tells whether this permissions
   # authorize the given authorizable object for the specific given role
   def role_authorizes?(role, authorizable)
     scope_for(role).authorizes?(authorizable)

--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -42,7 +42,7 @@ class Mumukit::Auth::Permissions
   end
 
   def granted_organizations_for(role)
-    scope_for(role)&.grants&.map { |grant| grant.to_mumukit_slug.organization }.to_set
+    scope_for(role)&.grants&.flat_map { |grant| grant.granted_organizations }.to_set
   end
 
   def add_permission!(role, *grants)

--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -12,12 +12,12 @@ class Mumukit::Auth::Permissions
     @scopes = scopes.with_indifferent_access
   end
 
-  def has_permission?(role, resource_slug)
-    Mumukit::Auth::Role.parse(role).allows?(resource_slug, self)
+  def has_permission?(role, authorizable)
+    Mumukit::Auth::Role.parse(role).allows?(authorizable, self)
   end
 
-  def role_allows?(role, resource_slug)
-    scope_for(role).allows?(resource_slug)
+  def role_allows?(role, authorizable)
+    scope_for(role).allows?(authorizable)
   end
 
   def has_role?(role)

--- a/lib/mumukit/auth/protection.rb
+++ b/lib/mumukit/auth/protection.rb
@@ -1,7 +1,7 @@
 module Mumukit::Auth::Protection
-  def protect!(role, slug)
+  def protect!(role, slug_like)
     raise Mumukit::Auth::UnauthorizedAccessError,
-          "Unauthorized access to #{slug} as #{role}. Scope is `#{scope_for role}`" unless has_permission?(role, slug)
+          "Unauthorized access to #{slug_like} as #{role}. Scope is `#{scope_for role}`" unless allows?(role, slug_like)
   end
 
   def protect_delegation!(other)

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -9,13 +9,13 @@ module Mumukit::Auth
     # by this role or its parent role
     #
     # This definition is recursive, thus traversing the whole ancenstry chain
-    def allows?(authorizable, permissions)
-      permissions.role_allows?(to_sym, authorizable) ||
-          parent_allows?(authorizable, permissions)
+    def authorizes?(authorizable, permissions)
+      permissions.role_authorizes?(to_sym, authorizable) ||
+          parent_authorizes?(authorizable, permissions)
     end
 
-    def parent_allows?(authorizable, permissions)
-      parent.allows?(authorizable, permissions)
+    def parent_authorizes?(authorizable, permissions)
+      parent.authorizes?(authorizable, permissions)
     end
 
     def to_sym
@@ -57,7 +57,7 @@ module Mumukit::Auth
     class Owner < Role
       parent nil
 
-      def parent_allows?(*)
+      def parent_authorizes?(*)
         false
       end
     end

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -4,7 +4,7 @@ module Mumukit::Auth
       @symbol=symbol
     end
 
-    # Tells wether the given authorizable object
+    # Tells whether the given authorizable object
     # can be authorized using the given permissions
     # by this role or its parent role
     #

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -4,13 +4,18 @@ module Mumukit::Auth
       @symbol=symbol
     end
 
-    def allows?(resource_slug, permissions)
-      permissions.role_allows?(to_sym, resource_slug) ||
-          parent_allows?(resource_slug, permissions)
+    # Tells wether the given authorizable object
+    # can be authorized using the given permissions
+    # by this role or its parent role
+    #
+    # This definition is recursive, thus traversing the whole ancenstry chain
+    def allows?(authorizable, permissions)
+      permissions.role_allows?(to_sym, authorizable) ||
+          parent_allows?(authorizable, permissions)
     end
 
-    def parent_allows?(resource_slug, permissions)
-      parent.allows?(resource_slug, permissions)
+    def parent_allows?(authorizable, permissions)
+      parent.allows?(authorizable, permissions)
     end
 
     def to_sym

--- a/lib/mumukit/auth/roles.rb
+++ b/lib/mumukit/auth/roles.rb
@@ -4,7 +4,7 @@ module Mumukit::Auth
 
     ROLES.each do |role|
       define_method "#{role}?" do |scope = Mumukit::Auth::Slug.any|
-        has_permission? role.to_sym, scope
+        allows? role.to_sym, scope
       end
     end
   end

--- a/lib/mumukit/auth/scope.rb
+++ b/lib/mumukit/auth/scope.rb
@@ -8,7 +8,7 @@ module Mumukit::Auth
     end
 
     def allows?(resource_slug)
-      any_grant? { |grant| grant.allows? resource_slug }
+      any_grant? { |grant| resource_slug.allowed_by? grant  }
     end
 
     def add_grant!(*grants)

--- a/lib/mumukit/auth/scope.rb
+++ b/lib/mumukit/auth/scope.rb
@@ -68,11 +68,11 @@ module Mumukit::Auth
     end
 
     def remove_narrower_grants!(grant)
-      grants.reject! { |it| grant.allows? it }
+      grants.reject! { |it| grant.includes? it }
     end
 
     def has_broader_grant?(grant)
-      grants.any? { |it| it.allows? grant }
+      grants.any? { |it| it.includes? grant }
     end
   end
 end

--- a/lib/mumukit/auth/scope.rb
+++ b/lib/mumukit/auth/scope.rb
@@ -11,6 +11,11 @@ module Mumukit::Auth
       any_grant? { |grant| authorizable.authorized_by? grant }
     end
 
+    # Similar to `authorizes?`, but specialized for slug-like objects
+    def allows?(slug_like)
+      authorizes? slug_like.to_mumukit_slug
+    end
+
     def add_grant!(*grants)
       grants.each { |grant| push_and_compact! grant }
     end

--- a/lib/mumukit/auth/scope.rb
+++ b/lib/mumukit/auth/scope.rb
@@ -7,8 +7,8 @@ module Mumukit::Auth
       add_grant! *grants
     end
 
-    def allows?(resource_slug)
-      any_grant? { |grant| resource_slug.allowed_by? grant  }
+    def allows?(authorizable)
+      any_grant? { |grant| authorizable.authorized_by? grant  }
     end
 
     def add_grant!(*grants)

--- a/lib/mumukit/auth/scope.rb
+++ b/lib/mumukit/auth/scope.rb
@@ -7,8 +7,8 @@ module Mumukit::Auth
       add_grant! *grants
     end
 
-    def allows?(authorizable)
-      any_grant? { |grant| authorizable.authorized_by? grant  }
+    def authorizes?(authorizable)
+      any_grant? { |grant| authorizable.authorized_by? grant }
     end
 
     def add_grant!(*grants)

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -18,8 +18,8 @@ module Mumukit::Auth
       raise 'Slug first part must be non-nil' unless first
       raise 'Slug second part must be non-nil' unless second
 
-      raise "Invalid first part format #{first}" unless first.match? /^[\w\-\.]+$/
-      raise "Invalid second part format #{second}" unless second.match? /^[\w\-\.]+$/
+      raise "Invalid first part format #{first}" unless first.match? /^[[[:alnum:]]\_\ \-\.]+$/
+      raise "Invalid second part format #{second}" unless second.match? /^[[[:alnum:]]\_\ \-\.]+$/
 
       @first = first
       @second = second

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -73,7 +73,7 @@ module Mumukit::Auth
       self
     end
 
-    # Tells wether the given grant
+    # Tells whether the given grant
     # is authorized by this slug
     #
     # This method exist in order to implement double dispatching

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -15,8 +15,11 @@ module Mumukit::Auth
     alias_method :content, :second
 
     def initialize(first, second)
-      raise 'slug first part must be non-nil' unless first
-      raise 'slug second part must be non-nil' unless second
+      raise 'Slug first part must be non-nil' unless first
+      raise 'Slug second part must be non-nil' unless second
+
+      raise "Invalid first part format #{first}" unless first.match? /^[\w\-\.]+$/
+      raise "Invalid second part format #{second}" unless second.match? /^[\w\-\.]+$/
 
       @first = first
       @second = second

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -2,10 +2,6 @@ class String
   def to_mumukit_slug
     Mumukit::Auth::Slug.parse self
   end
-
-  def authorized_by?(grant)
-    to_mumukit_slug.authorized_by?(grant)
-  end
 end
 
 module Mumukit::Auth

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -3,8 +3,8 @@ class String
     Mumukit::Auth::Slug.parse self
   end
 
-  def allowed_by?(grant)
-    to_mumukit_slug.allowed_by?(grant)
+  def authorized_by?(grant)
+    to_mumukit_slug.authorized_by?(grant)
   end
 end
 
@@ -72,7 +72,17 @@ module Mumukit::Auth
       self
     end
 
-    def allowed_by?(grant)
+    # Tells wether the given grant
+    # is authorized by this slug
+    #
+    # This method exist in order to implement double dispatching
+    # for both grant and slugs authorization
+    #
+    # See:
+    #  * `Mumukit::Auth::Grant::Base#authorized_by?`
+    #  * `Mumukit::Auth::Grant::Base#allows?
+    #  * `Mumukit::Auth::Grant::Base#includes?`
+    def authorized_by?(grant)
       grant.allows? self
     end
 

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -2,6 +2,10 @@ class String
   def to_mumukit_slug
     Mumukit::Auth::Slug.parse self
   end
+
+  def allowed_by?(grant)
+    to_mumukit_slug.allowed_by?(grant)
+  end
 end
 
 module Mumukit::Auth
@@ -66,6 +70,10 @@ module Mumukit::Auth
 
     def to_mumukit_slug
       self
+    end
+
+    def allowed_by?(grant)
+      grant.allows? self
     end
 
     def self.from_options(hash)

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -6,6 +6,8 @@ end
 
 module Mumukit::Auth
   class Slug
+    SLUG_REGEXP = /^[[[:alnum:]]\_\ \-\.]+$/
+
     attr_accessor :first, :second
 
     alias_method :organization, :first
@@ -18,8 +20,8 @@ module Mumukit::Auth
       raise 'Slug first part must be non-nil' unless first
       raise 'Slug second part must be non-nil' unless second
 
-      raise "Invalid first part format #{first}" unless first.match? /^[[[:alnum:]]\_\ \-\.]+$/
-      raise "Invalid second part format #{second}" unless second.match? /^[[[:alnum:]]\_\ \-\.]+$/
+      raise "Invalid first part format #{first}" unless first.match? SLUG_REGEXP
+      raise "Invalid second part format #{second}" unless second.match? SLUG_REGEXP
 
       @first = first
       @second = second

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -17,11 +17,11 @@ module Mumukit::Auth
     alias_method :content, :second
 
     def initialize(first, second)
-      raise 'Slug first part must be non-nil' unless first
-      raise 'Slug second part must be non-nil' unless second
+      raise Mumukit::Auth::InvalidSlugFormatError, 'Slug first part must be non-nil' unless first
+      raise Mumukit::Auth::InvalidSlugFormatError, 'Slug second part must be non-nil' unless second
 
-      raise "Invalid first part format #{first}" unless first.match? SLUG_REGEXP
-      raise "Invalid second part format #{second}" unless second.match? SLUG_REGEXP
+      raise Mumukit::Auth::InvalidSlugFormatError, "Invalid first part format #{first}" unless first.match? SLUG_REGEXP
+      raise Mumukit::Auth::InvalidSlugFormatError, "Invalid second part format #{second}" unless second.match? SLUG_REGEXP
 
       @first = first
       @second = second
@@ -133,7 +133,7 @@ module Mumukit::Auth
 
     def self.validate_slug!(slug)
       unless slug =~ /\A[^\/\n]+\/[^\/\n]+\z/
-        raise Mumukit::Auth::InvalidSlugFormatError, "Invalid slug: #{slug}. It must be in first/second format"
+        raise Mumukit::Auth::InvalidSlugFormatError, "Invalid slug #{slug}. It must be in first/second format"
       end
     end
   end

--- a/spec/mumukit/grant_spec.rb
+++ b/spec/mumukit/grant_spec.rb
@@ -90,7 +90,7 @@ describe Mumukit::Auth::Grant do
   end
 
   describe 'custom grant' do
-    class IncludesGrant < Mumukit::Auth::Grant
+    class IncludesGrant < Mumukit::Auth::Grant::Base
       def allows?(resource_slug)
         resource_slug.to_mumukit_slug.first.include? 'foo'
       end

--- a/spec/mumukit/grant_spec.rb
+++ b/spec/mumukit/grant_spec.rb
@@ -89,6 +89,16 @@ describe Mumukit::Auth::Grant do
     it { expect(Mumukit::Auth::Grant.parse('FOO/Bar').allows? 'foo/BAR').to be true }
   end
 
+  describe 'includes?' do
+    it { expect('foo/bar'.to_mumukit_grant.includes? 'foo/bar').to be true }
+    it { expect('foo/*'.to_mumukit_grant.includes? 'foo/*').to be true }
+    it { expect('foo/*'.to_mumukit_grant.includes? 'foo/bar').to be true }
+    it { expect('foo/bar'.to_mumukit_grant.includes? 'foo/*').to be false }
+    it { expect('*'.to_mumukit_grant.includes? 'foo/bar').to be true }
+    it { expect('foo/bar'.to_mumukit_grant.includes? '*').to be false }
+    xit { expect('foo/bar'.to_mumukit_grant.includes? '_/_').to raise_error('invalid grant') }
+  end
+
   describe 'custom grant' do
     class IncludesGrant < Mumukit::Auth::Grant::Base
       def allows?(authorizable)

--- a/spec/mumukit/grant_spec.rb
+++ b/spec/mumukit/grant_spec.rb
@@ -91,8 +91,8 @@ describe Mumukit::Auth::Grant do
 
   describe 'custom grant' do
     class IncludesGrant < Mumukit::Auth::Grant::Base
-      def allows?(resource_slug)
-        resource_slug.to_mumukit_slug.first.include? 'foo'
+      def allows?(authorizable)
+        authorizable.to_mumukit_slug.first.include? 'foo'
       end
 
       def to_s

--- a/spec/mumukit/grant_spec.rb
+++ b/spec/mumukit/grant_spec.rb
@@ -87,6 +87,9 @@ describe Mumukit::Auth::Grant do
 
     it { expect(grant.allows? 'FOO/BAR').to be true }
     it { expect(Mumukit::Auth::Grant.parse('FOO/Bar').allows? 'foo/BAR').to be true }
+
+    xit { expect('foo/bar'.to_mumukit_grant.includes? '*/*').to raise_error('invalid slug') }
+    xit { expect('foo/bar'.to_mumukit_grant.includes? '*').to raise_error('invalid slug') }
   end
 
   describe 'includes?' do
@@ -101,31 +104,32 @@ describe Mumukit::Auth::Grant do
 
   describe 'custom grant' do
     class IncludesGrant < Mumukit::Auth::Grant::Base
-      def allows?(authorizable)
-        authorizable.to_mumukit_slug.first.include? 'foo'
+      def allows?(slug_like)
+        slug_like.to_mumukit_slug.first.include? 'foo'
       end
 
       def to_s
-        '{includes:foo}'
-      end
-
-      def to_mumukit_slug
-        Mumukit::Auth::Slug.new '*', '*'
+        '{includesFoo}'
       end
 
       def self.try_parse(pattern)
-        new if pattern =~ /\{includes\:foo\}\/\*/
+        new if pattern =~ /\{includesFoo\}/
       end
     end
     before(:all) { Mumukit::Auth::Grant.add_custom_grant_type! IncludesGrant  }
     after(:all) { Mumukit::Auth::Grant.remove_custom_grant_type! IncludesGrant  }
 
-    let(:grant) { Mumukit::Auth::Grant.parse('{includes:foo}/*') }
+    let(:grant) { Mumukit::Auth::Grant.parse('{includesFoo}') }
 
     it { expect(Mumukit::Auth::Grant.custom_grant_types).to eq [IncludesGrant]}
     it { expect(grant.allows? 'foo/baz').to be true }
     it { expect(grant.allows? 'foobar/baz').to be true }
     it { expect(grant.allows? 'bar/baz').to be false }
 
+    it { expect(grant.includes? 'foo/baz').to be false }
+    it { expect(grant.includes? 'foobar/baz').to be false }
+    it { expect(grant.includes? 'bar/baz').to be false }
+
+    it { expect(grant.includes? '{includesFoo}').to be true }
   end
 end

--- a/spec/mumukit/grant_spec.rb
+++ b/spec/mumukit/grant_spec.rb
@@ -15,6 +15,7 @@ describe Mumukit::Auth::Grant do
     it { expect { '[foo]'.to_mumukit_grant }.to raise_error('Invalid slug grant. Cause: Invalid slug [foo]. It must be in first/second format') }
     it { expect { '{foo}'.to_mumukit_grant }.to raise_error('Invalid slug grant. Cause: Invalid slug {foo}. It must be in first/second format') }
     it { expect { '*/foo'.to_mumukit_grant }.to raise_error('Invalid slug grant. Cause: Invalid first part format *') }
+    it { expect { '_/*'.to_mumukit_grant }.to raise_error('Invalid first grant. First part must not be _') }
   end
 
   describe 'compare' do

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -208,7 +208,7 @@ describe Mumukit::Auth::Permissions do
     end
     context 'when all grant present organizations' do
       let(:permissions) { parse_permissions student: 'pdep/*:*' }
-      it { expect(permissions.student_granted_organizations.size).to eq 1 }
+      it { expect(permissions.student_granted_organizations.size).to eq 0 }
     end
     context 'when one organization appears twice' do
       let(:permissions) { parse_permissions student: 'pdep/*:pdep/*' }

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -109,8 +109,8 @@ describe Mumukit::Auth::Permissions do
     it { expect(permissions.owner?).to be true }
     it { expect(permissions.owner? 'test/student').to be true }
     it { expect(permissions.owner? 'test/_').to be true }
-    it { expect(permissions.owner? 'test/*').to be true }
-    it { expect(permissions.owner? '*/*').to be false }
+    it { expect { permissions.owner? 'test/*' }.to raise_error 'Invalid second part format *' }
+    it { expect { permissions.owner? '*/*' }.to raise_error 'Invalid first part format *' }
 
     it { expect(permissions.writer? 'test/student').to be true }
     it { expect(permissions.writer? 'test/_').to be true }
@@ -177,7 +177,7 @@ describe Mumukit::Auth::Permissions do
       before { permissions.add_permission!(:student, 'test/*') }
 
       it { expect(permissions.has_role? :student).to eq true }
-      it { expect(permissions.student? 'test/*').to eq true }
+      it { expect(permissions.student? 'test/_').to eq true }
 
       context 'when added twice' do
         before { permissions.add_permission! :student, 'test/*' }
@@ -219,23 +219,26 @@ describe Mumukit::Auth::Permissions do
   describe 'remove_permission!' do
     let(:permissions) { parse_permissions(student: 'foo/bar:test/*:foo/baz') }
 
+    it { expect { permissions.student? 'test/*' }.to raise_error 'Invalid second part format *' }
+    it { expect { permissions.student? '*' }.to raise_error 'Invalid slug: *. It must be in first/second format' }
+
     context 'when permission is present' do
       before { permissions.remove_permission!(:student, 'test/*') }
-      it { expect(permissions.student? 'test/*').to eq false }
+      it { expect(permissions.student? 'test/_').to eq false }
       it { expect(permissions.student? 'foo/bar').to eq true }
       it { expect(permissions.student? 'foo/baz').to eq true }
     end
 
     context 'when scope is not present' do
       before { permissions.remove_permission!(:student, 'baz/*') }
-      it { expect(permissions.student? 'test/*').to eq true }
+      it { expect(permissions.student? 'test/_').to eq true }
       it { expect(permissions.student? 'foo/bar').to eq true }
       it { expect(permissions.student? 'foo/baz').to eq true }
     end
 
     context 'when role is not present' do
       before { permissions.remove_permission!(:teacher, 'baz/*') }
-      it { expect(permissions.student? 'test/*').to eq true }
+      it { expect(permissions.student? 'test/_').to eq true }
       it { expect(permissions.student? 'foo/bar').to eq true }
       it { expect(permissions.student? 'foo/baz').to eq true }
     end
@@ -247,7 +250,7 @@ describe Mumukit::Auth::Permissions do
           headmaster: Mumukit::Auth::Scope.parse('foo/*'),
           owner: Mumukit::Auth::Scope.parse('test/*'))
     end
-    it { expect(permissions.student? 'test/*').to eq true }
+    it { expect(permissions.student? 'test/_').to eq true }
     it { expect(permissions.teacher? 'foo/bar').to eq true }
     it { expect(permissions.headmaster? 'foo/baz').to eq true }
     it { expect(permissions.headmaster? 'bar/baz').to eq false }

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -220,7 +220,7 @@ describe Mumukit::Auth::Permissions do
     let(:permissions) { parse_permissions(student: 'foo/bar:test/*:foo/baz') }
 
     it { expect { permissions.student? 'test/*' }.to raise_error 'Invalid second part format *' }
-    it { expect { permissions.student? '*' }.to raise_error 'Invalid slug: *. It must be in first/second format' }
+    it { expect { permissions.student? '*' }.to raise_error 'Invalid slug *. It must be in first/second format' }
 
     context 'when permission is present' do
       before { permissions.remove_permission!(:student, 'test/*') }

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -152,9 +152,9 @@ describe Mumukit::Auth::Permissions do
 
       it { expect(permissions.teacher? 'test/bar').to eq true }
 
-      it { expect(permissions.has_permission? :teacher, 'test/bar').to be true }
-      it { expect(permissions.has_permission? :teacher, 'Test/Bar').to be true }
-      it { expect(permissions.has_permission? :teacher, 'test/baz').to be false }
+      it { expect(permissions.allows? :teacher, 'test/bar').to be true }
+      it { expect(permissions.allows? :teacher, 'Test/Bar').to be true }
+      it { expect(permissions.allows? :teacher, 'test/baz').to be false }
 
       it { expect(permissions.as_json).to json_like(teacher: 'test/bar') }
 
@@ -162,14 +162,14 @@ describe Mumukit::Auth::Permissions do
         before { permissions.add_permission! :teacher, 'test/*' }
 
         it { expect(permissions).to json_like teacher: 'test/*' }
-        it { expect(permissions.has_permission? :teacher, 'test/baz').to be true }
+        it { expect(permissions.allows? :teacher, 'test/baz').to be true }
       end
 
       context 'when added broader grant with upcase' do
         before { permissions.add_permission! :teacher, 'Test/*' }
 
         it { expect(permissions).to json_like teacher: 'test/*' }
-        it { expect(permissions.has_permission? :teacher, 'test/baz').to be true }
+        it { expect(permissions.allows? :teacher, 'test/baz').to be true }
       end
     end
 

--- a/spec/mumukit/scope_spec.rb
+++ b/spec/mumukit/scope_spec.rb
@@ -4,25 +4,25 @@ describe Mumukit::Auth::Scope do
   describe 'one grant' do
     let(:scope) { Mumukit::Auth::Scope.parse('*') }
 
-    it { expect(scope.allows? 'foo/bar').to be true }
+    it { expect(scope.authorizes? 'foo/bar').to be true }
   end
 
   describe 'two scope' do
     let(:scope) { Mumukit::Auth::Scope.parse('foo/*:mumuki/*') }
 
-    it { expect(scope.allows? 'foo/bag').to be true }
-    it { expect(scope.allows? 'foo/baz').to be true }
-    it { expect(scope.allows? 'fooz/baz').to be false }
-    it { expect(scope.allows? 'xfoo/baz').to be false }
-    it { expect(scope.allows? 'mumuki/funcional').to be true }
-    it { expect(scope.allows? 'mumuki/logico').to be true }
-    it { expect(scope.allows? 'Mumuki/Logico').to be true }
+    it { expect(scope.authorizes? 'foo/bag').to be true }
+    it { expect(scope.authorizes? 'foo/baz').to be true }
+    it { expect(scope.authorizes? 'fooz/baz').to be false }
+    it { expect(scope.authorizes? 'xfoo/baz').to be false }
+    it { expect(scope.authorizes? 'mumuki/funcional').to be true }
+    it { expect(scope.authorizes? 'mumuki/logico').to be true }
+    it { expect(scope.authorizes? 'Mumuki/Logico').to be true }
   end
 
   describe 'grant none' do
     let(:scope) { Mumukit::Auth::Scope.parse('') }
 
-    it { expect(scope.allows? 'foo/bag').to be false }
-    it { expect(scope.allows? 'fooz/baz').to be false }
+    it { expect(scope.authorizes? 'foo/bag').to be false }
+    it { expect(scope.authorizes? 'fooz/baz').to be false }
   end
 end

--- a/spec/mumukit/scope_spec.rb
+++ b/spec/mumukit/scope_spec.rb
@@ -18,7 +18,7 @@ describe Mumukit::Auth::Scope do
     it { expect(scope.allows? 'mumuki/logico').to be true }
     it { expect(scope.allows? 'Mumuki/Logico').to be true }
 
-    xit { expect(scope.allows? 'Mumuki/*').to raise_error('invalid slug') }
+    it { expect { scope.allows? 'Mumuki/*' }.to raise_error('Invalid second part format *') }
   end
 
   describe 'grant none' do

--- a/spec/mumukit/scope_spec.rb
+++ b/spec/mumukit/scope_spec.rb
@@ -4,25 +4,27 @@ describe Mumukit::Auth::Scope do
   describe 'one grant' do
     let(:scope) { Mumukit::Auth::Scope.parse('*') }
 
-    it { expect(scope.authorizes? 'foo/bar').to be true }
+    it { expect(scope.allows? 'foo/bar').to be true }
   end
 
   describe 'two scope' do
     let(:scope) { Mumukit::Auth::Scope.parse('foo/*:mumuki/*') }
 
-    it { expect(scope.authorizes? 'foo/bag').to be true }
-    it { expect(scope.authorizes? 'foo/baz').to be true }
-    it { expect(scope.authorizes? 'fooz/baz').to be false }
-    it { expect(scope.authorizes? 'xfoo/baz').to be false }
-    it { expect(scope.authorizes? 'mumuki/funcional').to be true }
-    it { expect(scope.authorizes? 'mumuki/logico').to be true }
-    it { expect(scope.authorizes? 'Mumuki/Logico').to be true }
+    it { expect(scope.allows? 'foo/bag').to be true }
+    it { expect(scope.allows? 'foo/baz').to be true }
+    it { expect(scope.allows? 'fooz/baz').to be false }
+    it { expect(scope.allows? 'xfoo/baz').to be false }
+    it { expect(scope.allows? 'mumuki/funcional').to be true }
+    it { expect(scope.allows? 'mumuki/logico').to be true }
+    it { expect(scope.allows? 'Mumuki/Logico').to be true }
+
+    xit { expect(scope.allows? 'Mumuki/*').to raise_error('invalid slug') }
   end
 
   describe 'grant none' do
     let(:scope) { Mumukit::Auth::Scope.parse('') }
 
-    it { expect(scope.authorizes? 'foo/bag').to be false }
-    it { expect(scope.authorizes? 'fooz/baz').to be false }
+    it { expect(scope.allows? 'foo/bag').to be false }
+    it { expect(scope.allows? 'fooz/baz').to be false }
   end
 end

--- a/spec/mumukit/slug_spec.rb
+++ b/spec/mumukit/slug_spec.rb
@@ -39,7 +39,7 @@ describe Mumukit::Auth::Slug do
   it { expect(Mumukit::Auth::Slug.join_s(organization: 'foo', course: 'bar')).to eq 'foo/bar' }
 
   it { expect { Mumukit::Auth::Slug.join('foo', 'bar', 'baz') }.to raise_error 'Slugs must have up to two parts' }
-  it { expect { Mumukit::Auth::Slug.parse('baz') }.to raise_error 'Invalid slug: baz. It must be in first/second format' }
+  it { expect { Mumukit::Auth::Slug.parse('baz') }.to raise_error 'Invalid slug baz. It must be in first/second format' }
 
   it { expect(Mumukit::Auth::Slug.normalize('foo', 'bar').to_s).to eq 'foo/bar' }
   it { expect(Mumukit::Auth::Slug.normalize('Foo', 'Bar').to_s).to eq 'foo/bar' }

--- a/spec/mumukit/slug_spec.rb
+++ b/spec/mumukit/slug_spec.rb
@@ -5,6 +5,8 @@ describe Mumukit::Auth::Slug do
   it { expect('foo/bar--baz'.to_mumukit_slug.normalize).to eql  'foo/bar-baz'.to_mumukit_slug }
   it { expect('ein Bär/in München'.to_mumukit_slug.normalize).to eql  'ein-bar/in-munchen'.to_mumukit_slug }
 
+  it { expect { 'foo/*'.to_mumukit_slug }.to raise_error('Invalid second part format *') }
+
   it { expect('foo/baz'.to_mumukit_slug).to eq  'foo/baz'.to_mumukit_slug }
   it { expect('FOO/BAZ'.to_mumukit_slug).to eq  'foo/baz'.to_mumukit_slug }
   it { expect('Foo/Baz'.to_mumukit_slug).to eq  'FOO/BAZ'.to_mumukit_slug }
@@ -15,12 +17,12 @@ describe Mumukit::Auth::Slug do
 
   it { expect('foo/baz'.to_mumukit_slug.rebase('bar')).to eq  'bar/baz'.to_mumukit_slug }
 
-  it { expect('foo/*'.to_mumukit_slug == 'foo/*'.to_mumukit_slug).to be true }
-  it { expect('foo/*'.to_mumukit_slug.eql? 'foo/*'.to_mumukit_slug).to be true }
-  it { expect('foo/*'.to_mumukit_slug.hash == 'foo/*'.to_mumukit_slug.hash).to be true }
+  it { expect('foo/_'.to_mumukit_slug == 'foo/_'.to_mumukit_slug).to be true }
+  it { expect('foo/_'.to_mumukit_slug.eql? 'foo/_'.to_mumukit_slug).to be true }
+  it { expect('foo/_'.to_mumukit_slug.hash == 'foo/_'.to_mumukit_slug.hash).to be true }
 
-  it { expect { Mumukit::Auth::Slug.new(nil, 'bar') }.to raise_error 'slug first part must be non-nil' }
-  it { expect { Mumukit::Auth::Slug.new('foo', nil) }.to raise_error 'slug second part must be non-nil' }
+  it { expect { Mumukit::Auth::Slug.new(nil, 'bar') }.to raise_error 'Slug first part must be non-nil' }
+  it { expect { Mumukit::Auth::Slug.new('foo', nil) }.to raise_error 'Slug second part must be non-nil' }
 
   it { expect(Mumukit::Auth::Slug.new('foo', 'bar').to_s).to eq 'foo/bar' }
   it { expect(Mumukit::Auth::Slug.parse('foo/bar').to_s).to eq 'foo/bar' }
@@ -48,7 +50,7 @@ describe Mumukit::Auth::Slug do
   it { expect { Mumukit::Auth::Slug.validate_slug!('foo-bar/baz') }.to_not raise_error }
   it { expect { Mumukit::Auth::Slug.validate_slug!('FOO.baR/bAz') }.to_not raise_error }
   it { expect { Mumukit::Auth::Slug.validate_slug!('123/!@#') }.to_not raise_error }
-  
+
   it { expect { Mumukit::Auth::Slug.validate_slug!('/') }.to raise_error }
   it { expect { Mumukit::Auth::Slug.validate_slug!('foo/') }.to raise_error }
   it { expect { Mumukit::Auth::Slug.validate_slug!('/bar') }.to raise_error }


### PR DESCRIPTION
This PR refactors in a non backward-compatible way some important slugs and grants semantics: 

* Grants can not be converted to slugs anymore - `to_mumukit_slug` was removed
* `*/*`-like strings are not a valid slugs anymore
* `_/_`-like strings are not valid grants anymore
* `Permissions.has_permissions?` has been deprecated
* Several methods have being renamed
* Now it is possible to define new custom grants
* Authorization of slugs and grants is now split into two different methods: `allows?` and `includes?`
* `authorized_by?` is now provided as a way to use slugs and grant polymorphically, using a double dispatch 
* Validation messages have been improved 
* Now `granted_organizations` is provided as a way to tell which are the explicitly granted organizations for a grant, instead of depending on `to_mumukit_slug`