### PR TITLE
Feature introduce admin permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ a_grant.to_s
 ### Roles
 
 ```ruby
-Mumukit::Auth::Roles.ROLES # answers [:student, :teacher, :headmaster, :writer, :editor, :janitor, :owner]
+Mumukit::Auth::Roles.ROLES # answers [:student, :teacher, :headmaster, :writer, :editor, :janitor, :admin, :owner]
 ```
 
 ### Permissions

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -41,12 +41,15 @@ module Mumukit::Auth
       parent :editor
     end
     class Editor < Role
-      parent :owner
+      parent :admin
     end
     class Janitor < Role
-      parent :owner
+      parent :admin
     end
     class Moderator < Role
+      parent :admin
+    end
+    class Admin < Role
       parent :owner
     end
     class Owner < Role

--- a/lib/mumukit/auth/roles.rb
+++ b/lib/mumukit/auth/roles.rb
@@ -1,6 +1,6 @@
 module Mumukit::Auth
   module Roles
-    ROLES = [:student, :teacher, :headmaster, :writer, :editor, :janitor, :moderator, :owner]
+    ROLES = [:student, :teacher, :headmaster, :writer, :editor, :janitor, :moderator, :admin, :owner]
 
     ROLES.each do |role|
       define_method "#{role}?" do |scope = Mumukit::Auth::Slug.any|


### PR DESCRIPTION
This PR introduces a new permission that is like owner, but with less power. 

It should be preferred in the future over `owner`, leaving that permission to actually too-risky operations. 