### PR TITLE
Chore granted organizations method rename

### DIFF
--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -28,14 +28,7 @@ class Mumukit::Auth::Permissions
     self.scopes[role] ||= Mumukit::Auth::Scope.new
   end
 
-  # Deprecated: use `student_granted_organizations` organizations instead
-  def accessible_organizations
-    warn "Don't use accessible_organizations, since this method is probably not doing what you would expect.\n" +
-         "Use student_granted_organizations if you still need its behaviour"
-    student_granted_organizations
-  end
-
-  # Answers the organizations for which the user has been explicitly granted acceses as student.
+  # Answers the organizations for which the user has been explicitly granted access as student.
   # This method does not include the organizations the user has access because of the roles hierarchy
   def student_granted_organizations
     granted_organizations_for :student

--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -30,11 +30,11 @@ class Mumukit::Auth::Permissions
 
   # Answers the organizations for which the user has been explicitly granted access as student.
   # This method does not include the organizations the user has access because of the roles hierarchy
-  def student_granted_organizations
+  def student_granted_organizations_names
     granted_organizations_for :student
   end
 
-  def any_granted_organizations
+  def any_granted_organizations_names
     scopes.values.flat_map(&:grants).map(&:organization).to_set
   end
 

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -224,54 +224,54 @@ describe Mumukit::Auth::Permissions do
     end
   end
 
-  describe '#student_granted_organizations' do
+  describe '#student_granted_organizations_names' do
     context 'when there is one organization' do
       let(:permissions) { parse_permissions student: 'pdep/*' }
-      it { expect(permissions.student_granted_organizations.size).to eq 1 }
+      it { expect(permissions.student_granted_organizations_names.size).to eq 1 }
     end
     context 'when there are granted organization with other roles' do
       let(:permissions) { parse_permissions student: 'pdep/*', teacher: 'alcal/*' }
-      it { expect(permissions.student_granted_organizations.size).to eq 1 }
+      it { expect(permissions.student_granted_organizations_names.size).to eq 1 }
     end
     context 'when there are two organizations' do
       let(:permissions) { parse_permissions student: 'pdep/*:alcal/*' }
-      it { expect(permissions.student_granted_organizations.size).to eq 2 }
+      it { expect(permissions.student_granted_organizations_names.size).to eq 2 }
     end
     context 'when all grant present organizations' do
       let(:permissions) { parse_permissions student: 'pdep/*:*' }
-      it { expect(permissions.student_granted_organizations.size).to eq 1 }
+      it { expect(permissions.student_granted_organizations_names.size).to eq 1 }
     end
     context 'when one organization appears twice' do
       let(:permissions) { parse_permissions student: 'pdep/*:pdep/*' }
-      it { expect(permissions.student_granted_organizations.size).to eq 1 }
+      it { expect(permissions.student_granted_organizations_names.size).to eq 1 }
     end
   end
 
-  describe '#any_granted_organizations' do
+  describe '#any_granted_organizations_names' do
     context 'when there is one organization' do
       let(:permissions) { parse_permissions student: 'pdep/*' }
-      it { expect(permissions.any_granted_organizations.size).to eq 1 }
-      it { expect(permissions.any_granted_organizations).to eq Set['pdep'] }
+      it { expect(permissions.any_granted_organizations_names.size).to eq 1 }
+      it { expect(permissions.any_granted_organizations_names).to eq Set['pdep'] }
     end
     context 'when there are granted organization with other roles' do
       let(:permissions) { parse_permissions student: 'pdep/*', teacher: 'alcal/*' }
-      it { expect(permissions.any_granted_organizations.size).to eq 2 }
-      it { expect(permissions.any_granted_organizations).to eq Set['pdep', 'alcal'] }
+      it { expect(permissions.any_granted_organizations_names.size).to eq 2 }
+      it { expect(permissions.any_granted_organizations_names).to eq Set['pdep', 'alcal'] }
     end
     context 'when there are two organizations' do
       let(:permissions) { parse_permissions student: 'pdep/*:alcal/*' }
-      it { expect(permissions.any_granted_organizations.size).to eq 2 }
-      it { expect(permissions.any_granted_organizations).to eq Set['pdep', 'alcal'] }
+      it { expect(permissions.any_granted_organizations_names.size).to eq 2 }
+      it { expect(permissions.any_granted_organizations_names).to eq Set['pdep', 'alcal'] }
     end
     context 'when all grant present organizations' do
       let(:permissions) { parse_permissions student: 'pdep/*:*' }
-      it { expect(permissions.any_granted_organizations.size).to eq 1 }
-      it { expect(permissions.any_granted_organizations).to eq Set['*'] }
+      it { expect(permissions.any_granted_organizations_names.size).to eq 1 }
+      it { expect(permissions.any_granted_organizations_names).to eq Set['*'] }
     end
     context 'when one organization appears twice' do
       let(:permissions) { parse_permissions student: 'pdep/*:pdep/*' }
-      it { expect(permissions.any_granted_organizations.size).to eq 1 }
-      it { expect(permissions.any_granted_organizations).to eq Set['pdep'] }
+      it { expect(permissions.any_granted_organizations_names.size).to eq 1 }
+      it { expect(permissions.any_granted_organizations_names).to eq Set['pdep'] }
     end
   end
 


### PR DESCRIPTION
You'll find the motivation for this one on https://github.com/mumuki/mumuki-domain/pull/178

Apart from that I'm actually dropping the long deprecated method `accessible_organizations`