### PR TITLE
Feature permissions compact

### DIFF
--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -60,9 +60,7 @@ class Mumukit::Auth::Permissions
 
   def add_scopes!(scopes)
     raise 'invalid scopes' if scopes.any? { |key, value| value.class != Mumukit::Auth::Scope }
-    scopes.each do |role, scope|
-      add_permission! role, *scope.grants
-    end
+    scopes.each { |role, scope| add_permission! role, *scope.grants }
   end
 
   def merge(other)

--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -13,7 +13,7 @@ class Mumukit::Auth::Permissions
   end
 
   def has_permission?(role, resource_slug)
-    Mumukit::Auth::Role.parse(role).allows?(resource_slug, self)
+    Mumukit::Auth::Role[role].allows?(resource_slug, self)
   end
 
   def role_allows?(role, resource_slug)
@@ -26,6 +26,17 @@ class Mumukit::Auth::Permissions
 
   def scope_for(role)
     self.scopes[role] ||= Mumukit::Auth::Scope.new
+  end
+
+  def compact!
+    old_scopes = @scopes.dup
+    @scopes = {}.with_indifferent_access
+
+    old_scopes.each do |role, scope|
+      scope.grants.each do |grant|
+        push_and_compact! role, grant
+      end
+    end
   end
 
   # Deprecated: use `student_granted_organizations` organizations instead
@@ -54,7 +65,7 @@ class Mumukit::Auth::Permissions
   end
 
   def add_permission!(role, *grants)
-    scope_for(role).add_grant! *grants
+    grants.each { |grant| push_and_compact! role, grant }
   end
 
   def merge(other)
@@ -146,4 +157,19 @@ class Mumukit::Auth::Permissions
     scope.grants.all? { |grant| has_permission? role, grant }
   end
 
+  def push_and_compact!(role, grant)
+    role = Mumukit::Auth::Role[role] # FIXME
+    grant = grant.to_mumukit_grant   # FIXME
+
+    scopes.each do |other_role, other_scope|
+      other_role = Mumukit::Auth::Role[other_role]
+
+      if other_role.narrower_than?(role)
+        other_scope.remove_narrower_grants!(grant)
+      elsif other_role.broader_than?(role) && other_scope.has_broader_grant?(grant)
+        return
+      end
+    end
+    scope_for(role.to_sym).add_grant! grant
+  end
 end

--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -2,8 +2,6 @@ class Mumukit::Auth::Permissions
   include Mumukit::Auth::Roles
   include Mumukit::Auth::Protection
 
-  delegate :empty?, to: :scopes
-
   attr_accessor :scopes
 
   def initialize(scopes={})
@@ -27,6 +25,20 @@ class Mumukit::Auth::Permissions
     self.scopes[role] ||= Mumukit::Auth::Scope.new
   end
 
+  def empty?
+    scopes.all? {|_, it| it.empty? }
+  end
+
+  def compact!
+    old_scopes = @scopes.dup
+    @scopes = {}.with_indifferent_access
+
+    old_scopes.each do |role, scope|
+      scope.grants.each do |grant|
+        push_and_compact! role, grant
+      end
+    end
+  end
 
   # Deprecated: use `student_granted_organizations` organizations instead
   def accessible_organizations

--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -12,7 +12,7 @@ class Mumukit::Auth::Permissions
   end
 
   def has_permission?(role, resource_slug)
-    Mumukit::Auth::Role[role].allows?(resource_slug, self)
+    role.to_mumukit_role.allows?(resource_slug, self)
   end
 
   def role_allows?(role, resource_slug)
@@ -54,6 +54,7 @@ class Mumukit::Auth::Permissions
   end
 
   def add_permission!(role, *grants)
+    role = role.to_mumukit_role
     grants.each { |grant| push_and_compact! role, grant }
   end
 
@@ -154,11 +155,11 @@ class Mumukit::Auth::Permissions
   end
 
   def push_and_compact!(role, grant)
-    role = Mumukit::Auth::Role[role] # FIXME
-    grant = grant.to_mumukit_grant   # FIXME
+    role = role.to_mumukit_role
+    grant = grant.to_mumukit_grant
 
     scopes.each do |other_role, other_scope|
-      other_role = Mumukit::Auth::Role[other_role]
+      other_role = other_role.to_mumukit_role
 
       if other_role.narrower_than?(role)
         other_scope.remove_narrower_grants!(grant)

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -17,7 +17,15 @@ module Mumukit::Auth
       @symbol
     end
 
+    def superseded_by?(other)
+      other.class != self.class && superseded_by_other?(other)
+    end
+
     private
+
+    def superseded_by_other?(other)
+      self.parent.class == other.class || self.parent.superseded_by?(other)
+    end
 
     def self.parent(parent)
       define_method(:parent) { self.class.parse(parent) }
@@ -62,6 +70,10 @@ module Mumukit::Auth
       parent nil
 
       def parent_allows?(*)
+        false
+      end
+
+      def superseded_by_other?(*)
         false
       end
     end

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -1,3 +1,16 @@
+
+class String
+  def to_mumukit_role
+    Mumukit::Auth::Role.parse self
+  end
+end
+
+class Symbol
+  def to_mumukit_role
+    Mumukit::Auth::Role.parse self
+  end
+end
+
 module Mumukit::Auth
   class Role
     def initialize(symbol)
@@ -25,6 +38,10 @@ module Mumukit::Auth
       other.class != self.class && narrower_than_other?(other)
     end
 
+    def to_mumukit_role
+      self
+    end
+
     private
 
     def narrower_than_other?(other)
@@ -38,12 +55,9 @@ module Mumukit::Auth
 
       def parse(role)
         @roles ||= {}
-        @roles[role] ||= "Mumukit::Auth::Role::#{role.to_s.camelize}".constantize.new(role.to_sym)
+        @roles[role.to_sym] ||= "Mumukit::Auth::Role::#{role.to_s.camelize}".constantize.new(role.to_sym)
       end
-
-      alias [] parse
     end
-
 
     class ExStudent < Role
       parent :student

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -35,17 +35,15 @@ module Mumukit::Auth
     end
 
     def narrower_than?(other)
-      other.class != self.class && narrower_than_other?(other)
+      other.class != self.class && _narrower_than_other?(other)
     end
 
     def to_mumukit_role
       self
     end
 
-    private
-
-    def narrower_than_other?(other)
-      self.parent.class == other.class || self.parent.narrower_than?(other)
+    def _narrower_than_other?(other)
+      self.parent.class == other.class || self.parent._narrower_than_other?(other)
     end
 
     class << self
@@ -96,7 +94,7 @@ module Mumukit::Auth
         false
       end
 
-      def narrower_than_other?(*)
+      def _narrower_than_other?(*)
         false
       end
     end

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -17,24 +17,33 @@ module Mumukit::Auth
       @symbol
     end
 
-    def superseded_by?(other)
-      other.class != self.class && superseded_by_other?(other)
+    def broader_than?(other)
+      other.narrower_than? self
+    end
+
+    def narrower_than?(other)
+      other.class != self.class && narrower_than_other?(other)
     end
 
     private
 
-    def superseded_by_other?(other)
-      self.parent.class == other.class || self.parent.superseded_by?(other)
+    def narrower_than_other?(other)
+      self.parent.class == other.class || self.parent.narrower_than?(other)
     end
 
-    def self.parent(parent)
-      define_method(:parent) { self.class.parse(parent) }
+    class << self
+      def parent(parent)
+        define_method(:parent) { self.class.parse(parent) }
+      end
+
+      def parse(role)
+        @roles ||= {}
+        @roles[role] ||= "Mumukit::Auth::Role::#{role.to_s.camelize}".constantize.new(role.to_sym)
+      end
+
+      alias [] parse
     end
 
-    def self.parse(role)
-      @roles ||= {}
-      @roles[role] ||= "Mumukit::Auth::Role::#{role.to_s.camelize}".constantize.new(role.to_sym)
-    end
 
     class ExStudent < Role
       parent :student
@@ -73,7 +82,7 @@ module Mumukit::Auth
         false
       end
 
-      def superseded_by_other?(*)
+      def narrower_than_other?(*)
         false
       end
     end

--- a/lib/mumukit/auth/scope.rb
+++ b/lib/mumukit/auth/scope.rb
@@ -54,6 +54,14 @@ module Mumukit::Auth
       to_s
     end
 
+    def remove_narrower_grants!(grant)
+      grants.reject! { |it| grant.allows? it }
+    end
+
+    def has_broader_grant?(grant)
+      grants.any? { |it| it.allows? grant }
+    end
+
     private
 
     def any_grant?(&block)
@@ -65,14 +73,6 @@ module Mumukit::Auth
       return if has_broader_grant? grant
       remove_narrower_grants! grant
       grants << grant
-    end
-
-    def remove_narrower_grants!(grant)
-      grants.reject! { |it| grant.allows? it }
-    end
-
-    def has_broader_grant?(grant)
-      grants.any? { |it| it.allows? grant }
     end
   end
 end

--- a/lib/mumukit/auth/scope.rb
+++ b/lib/mumukit/auth/scope.rb
@@ -20,6 +20,10 @@ module Mumukit::Auth
       self.grants.delete(grant)
     end
 
+    def empty?
+      grants.empty?
+    end
+
     def merge(other)
       self.class.new grants + other.grants
     end

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -187,7 +187,28 @@ describe Mumukit::Auth::Permissions do
 
   describe 'add_permission!' do
     let(:permissions) { parse_permissions({}) }
-    context 'when no teacher permissions added' do
+
+    context 'when student and then teacher permissions added' do
+      before { permissions.add_permission!(:student, 'test/bar') }
+      before { permissions.add_permission!(:teacher, 'test/bar') }
+
+      it { expect(permissions.has_role? :student).to be false }
+      it { expect(permissions.has_role? :teacher).to eq true }
+
+      it { expect(permissions.teacher? 'test/bar').to eq true }
+    end
+
+    context 'when teacher and then student permissions added' do
+      before { permissions.add_permission!(:teacher, 'test/bar') }
+      before { permissions.add_permission!(:student, 'test/bar') }
+
+      it { expect(permissions.has_role? :student).to be false }
+      it { expect(permissions.has_role? :teacher).to eq true }
+
+      it { expect(permissions.teacher? 'test/bar').to eq true }
+    end
+
+    context 'when teacher permissions added' do
       before { permissions.add_permission!(:teacher, 'test/bar') }
 
       it { expect(permissions.has_role? :student).to be false }

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -12,7 +12,23 @@ describe Mumukit::Auth::Permissions do
   end
 
   describe '#parse' do
-    it { expect(Mumukit::Auth::Permissions.parse(nil)).to be_empty }
+    context 'when nil permissions' do
+      it { expect(Mumukit::Auth::Permissions.parse(nil)).to be_empty }
+    end
+
+    context 'when roles can be compacted' do
+      let(:permissions) do
+        parse_permissions writer: 'test/content-1:test/content-2:other/*',
+                          editor: 'test/*:other/course-2',
+                          student: 'other/course-1:test/course-2',
+                          headmaster: 'other/*'
+      end
+
+      it { expect(permissions.to_h).to eq 'writer' => 'other/*',
+                                          'editor' => 'test/*:other/course-2',
+                                          'student' => 'test/course-2',
+                                          'headmaster' => 'other/*' }
+    end
   end
 
   describe '#merge' do
@@ -22,9 +38,15 @@ describe Mumukit::Auth::Permissions do
     it { expect(permissions.merge(permissions)).to json_like(permissions) }
 
     it do
+      permissions_1 = parse_permissions student: 'foo/foobar', teacher: 'foo/bar', owner: 'foobar/baz'
+      permissions_2 = parse_permissions student: 'foo/baz', teacher: 'foo/bar', owner: 'bar/baz'
+      expect(permissions_1.merge(permissions_2)).to json_like student: 'foo/foobar:foo/baz', teacher: 'foo/bar', owner: 'foobar/baz:bar/baz'
+    end
+
+    it "compacts roles when able to do so" do
       permissions_1 = parse_permissions student: 'foo/*', teacher: 'foo/baz', owner: 'foobar/baz'
       permissions_2 = parse_permissions student: 'foo/baz', teacher: 'foo/*', owner: 'bar/baz'
-      expect(permissions_1.merge(permissions_2)).to json_like student: 'foo/*', teacher: 'foo/*', owner: 'foobar/baz:bar/baz'
+      expect(permissions_1.merge(permissions_2)).to json_like student: '', teacher: 'foo/*', owner: 'foobar/baz:bar/baz'
     end
   end
 
@@ -185,7 +207,7 @@ describe Mumukit::Auth::Permissions do
     it { expect(Mumukit::Auth::Permissions.parse(student: 'foo/bar:baz/goo').grant_strings_for :student).to eq ['foo/bar', 'baz/goo'] }
   end
 
-  describe 'add_permission!' do
+  describe '#add_permission!' do
     let(:permissions) { parse_permissions({}) }
 
     context 'when student and then teacher permissions added' do

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -31,6 +31,14 @@ describe Mumukit::Auth::Permissions do
     end
   end
 
+  describe '#empty?' do
+    it { expect(parse_permissions(student: '')).to be_empty }
+    it { expect(parse_permissions(student: '', teacher: '')).to be_empty }
+
+    it { expect(parse_permissions(student: 'foo/bar')).to_not be_empty }
+    it { expect(parse_permissions(student: 'foo/bar', teacher: '')).to_not be_empty }
+  end
+
   describe '#merge' do
     it { expect(Mumukit::Auth::Permissions.new.merge(Mumukit::Auth::Permissions.new)).to json_like({}) }
     it { expect(permissions.merge(Mumukit::Auth::Permissions.new)).to json_like permissions }

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -278,6 +278,8 @@ describe Mumukit::Auth::Permissions do
       it { expect(permissions.has_permission? :teacher, 'Test/Bar').to be true }
       it { expect(permissions.has_permission? :teacher, 'test/baz').to be false }
 
+      it { expect(permissions.has_permission? :teacher.to_mumukit_role, 'test/bar').to be true }
+
       it { expect(permissions.as_json).to json_like(teacher: 'test/bar') }
 
       context 'when added broader grant' do

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -190,22 +190,58 @@ describe Mumukit::Auth::Permissions do
 
     context 'when student and then teacher permissions added' do
       before { permissions.add_permission!(:student, 'test/bar') }
-      before { permissions.add_permission!(:teacher, 'test/bar') }
 
-      it { expect(permissions.has_role? :student).to be false }
-      it { expect(permissions.has_role? :teacher).to eq true }
+      context 'when exact same course is used' do
+        before { permissions.add_permission!(:teacher, 'test/bar') }
 
-      it { expect(permissions.teacher? 'test/bar').to eq true }
+        it { expect(permissions.has_role? :student).to be false }
+        it { expect(permissions.has_role? :teacher).to eq true }
+
+        it { expect(permissions.student? 'test/bar').to eq true }
+        it { expect(permissions.student? 'test/baz').to eq false }
+        it { expect(permissions.teacher? 'test/bar').to eq true }
+        it { expect(permissions.teacher? 'test/baz').to eq false }
+      end
+
+      context 'when wider grant is used' do
+        before { permissions.add_permission!(:teacher, 'test/*') }
+
+        it { expect(permissions.has_role? :student).to be false }
+        it { expect(permissions.has_role? :teacher).to eq true }
+
+        it { expect(permissions.student? 'test/bar').to eq true }
+        it { expect(permissions.student? 'test/baz').to eq true }
+        it { expect(permissions.teacher? 'test/bar').to eq true }
+        it { expect(permissions.teacher? 'test/baz').to eq true }
+      end
     end
 
     context 'when teacher and then student permissions added' do
       before { permissions.add_permission!(:teacher, 'test/bar') }
-      before { permissions.add_permission!(:student, 'test/bar') }
 
-      it { expect(permissions.has_role? :student).to be false }
-      it { expect(permissions.has_role? :teacher).to eq true }
+      context 'when exact same course is used' do
+        before { permissions.add_permission!(:student, 'test/bar') }
 
-      it { expect(permissions.teacher? 'test/bar').to eq true }
+        it { expect(permissions.has_role? :student).to be false }
+        it { expect(permissions.has_role? :teacher).to eq true }
+
+        it { expect(permissions.student? 'test/bar').to eq true }
+        it { expect(permissions.student? 'test/baz').to eq false }
+        it { expect(permissions.teacher? 'test/bar').to eq true }
+        it { expect(permissions.teacher? 'test/baz').to eq false }
+      end
+
+      context 'when wider grant is used' do
+        before { permissions.add_permission!(:student, 'test/*') }
+
+        it { expect(permissions.has_role? :student).to be true }
+        it { expect(permissions.has_role? :teacher).to eq true }
+
+        it { expect(permissions.student? 'test/bar').to eq true }
+        it { expect(permissions.student? 'test/baz').to eq true }
+        it { expect(permissions.teacher? 'test/bar').to eq true }
+        it { expect(permissions.teacher? 'test/baz').to eq false }
+      end
     end
 
     context 'when teacher permissions added' do

--- a/spec/mumukit/roles_spec.rb
+++ b/spec/mumukit/roles_spec.rb
@@ -2,18 +2,20 @@ require_relative '../spec_helper'
 
 describe Mumukit::Auth::Role do
 
-  it { expect(Mumukit::Auth::Role[:student]).to be Mumukit::Auth::Role[:student] }
-  it { expect(Mumukit::Auth::Role[:student]).to be_a Mumukit::Auth::Role::Student }
+  it { expect(:student.to_mumukit_role).to be :student.to_mumukit_role }
+  it { expect('student'.to_mumukit_role).to be :student.to_mumukit_role }
+  it { expect(:student.to_mumukit_role.to_mumukit_role).to be :student.to_mumukit_role }
+  it { expect(:student.to_mumukit_role).to be_a Mumukit::Auth::Role::Student }
 
   describe 'narrower_than?' do
-    it { expect(Mumukit::Auth::Role[:student]).to be_narrower_than Mumukit::Auth::Role[:teacher] }
-    it { expect(Mumukit::Auth::Role[:student]).to be_narrower_than Mumukit::Auth::Role[:admin] }
-    it { expect(Mumukit::Auth::Role[:student]).to be_narrower_than Mumukit::Auth::Role[:owner] }
+    it { expect(:student.to_mumukit_role).to be_narrower_than :teacher.to_mumukit_role }
+    it { expect(:student.to_mumukit_role).to be_narrower_than :admin.to_mumukit_role }
+    it { expect(:student.to_mumukit_role).to be_narrower_than :owner.to_mumukit_role }
 
-    it { expect(Mumukit::Auth::Role[:student]).to_not be_narrower_than Mumukit::Auth::Role[:ex_student] }
-    it { expect(Mumukit::Auth::Role[:editor]).to_not be_narrower_than Mumukit::Auth::Role[:student] }
+    it { expect(:student.to_mumukit_role).to_not be_narrower_than :ex_student.to_mumukit_role }
+    it { expect(:editor.to_mumukit_role).to_not be_narrower_than :student.to_mumukit_role }
 
-    it { expect(Mumukit::Auth::Role[:ex_student]).to be_narrower_than Mumukit::Auth::Role[:student] }
-    it { expect(Mumukit::Auth::Role[:ex_student]).to be_narrower_than Mumukit::Auth::Role[:admin] }
+    it { expect(:ex_student.to_mumukit_role).to be_narrower_than :student.to_mumukit_role }
+    it { expect(:ex_student.to_mumukit_role).to be_narrower_than :admin.to_mumukit_role }
   end
 end

--- a/spec/mumukit/roles_spec.rb
+++ b/spec/mumukit/roles_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../spec_helper'
+
+describe Mumukit::Auth::Role do
+
+  it { expect(Mumukit::Auth::Role[:student]).to be Mumukit::Auth::Role[:student] }
+  it { expect(Mumukit::Auth::Role[:student]).to be_a Mumukit::Auth::Role::Student }
+
+  describe 'narrower_than?' do
+    it { expect(Mumukit::Auth::Role[:student]).to be_narrower_than Mumukit::Auth::Role[:teacher] }
+    it { expect(Mumukit::Auth::Role[:student]).to be_narrower_than Mumukit::Auth::Role[:admin] }
+    it { expect(Mumukit::Auth::Role[:student]).to be_narrower_than Mumukit::Auth::Role[:owner] }
+
+    it { expect(Mumukit::Auth::Role[:student]).to_not be_narrower_than Mumukit::Auth::Role[:ex_student] }
+    it { expect(Mumukit::Auth::Role[:editor]).to_not be_narrower_than Mumukit::Auth::Role[:student] }
+
+    it { expect(Mumukit::Auth::Role[:ex_student]).to be_narrower_than Mumukit::Auth::Role[:student] }
+    it { expect(Mumukit::Auth::Role[:ex_student]).to be_narrower_than Mumukit::Auth::Role[:admin] }
+  end
+end

--- a/spec/mumukit/slug_spec.rb
+++ b/spec/mumukit/slug_spec.rb
@@ -48,10 +48,10 @@ describe Mumukit::Auth::Slug do
   it { expect { Mumukit::Auth::Slug.validate_slug!('foo-bar/baz') }.to_not raise_error }
   it { expect { Mumukit::Auth::Slug.validate_slug!('FOO.baR/bAz') }.to_not raise_error }
   it { expect { Mumukit::Auth::Slug.validate_slug!('123/!@#') }.to_not raise_error }
-  
-  it { expect { Mumukit::Auth::Slug.validate_slug!('/') }.to raise_error }
-  it { expect { Mumukit::Auth::Slug.validate_slug!('foo/') }.to raise_error }
-  it { expect { Mumukit::Auth::Slug.validate_slug!('/bar') }.to raise_error }
-  it { expect { Mumukit::Auth::Slug.validate_slug!('foo/bar/baz') }.to raise_error }
-  it { expect { Mumukit::Auth::Slug.validate_slug!("foo/bar\nbaz") }.to raise_error }
+
+  it { expect { Mumukit::Auth::Slug.validate_slug!('/') }.to raise_error Mumukit::Auth::InvalidSlugFormatError }
+  it { expect { Mumukit::Auth::Slug.validate_slug!('foo/') }.to raise_error Mumukit::Auth::InvalidSlugFormatError }
+  it { expect { Mumukit::Auth::Slug.validate_slug!('/bar') }.to raise_error Mumukit::Auth::InvalidSlugFormatError }
+  it { expect { Mumukit::Auth::Slug.validate_slug!('foo/bar/baz') }.to raise_error Mumukit::Auth::InvalidSlugFormatError }
+  it { expect { Mumukit::Auth::Slug.validate_slug!("foo/bar\nbaz") }.to raise_error Mumukit::Auth::InvalidSlugFormatError }
 end


### PR DESCRIPTION
# :dart:  Goal

To compact permissions when parsing and updating

# :memo: Details

This PR refactors the role objects, to make them a bit more robust. It also removes narrower permissions when wider ones are added. Conversely, it avoids adding narrower permissions when wider permissions already exist. 

I used a similar design to the grants `push_and_compact!` method, which allow me to reuse a bunch of private methods. 

