### PR TITLE
Improve slug normalization methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,26 +47,32 @@ Usage:
 ```ruby
 
 # Creation
-Mumukit::Auth:Slug.new('first', 'second')
-Mumukit::Auth:Slug.from_options(first: 'hello', second: 'world')
-Mumukit::Auth:Slug.from_options(organization: 'hello', repository: 'world')
+Mumukit::Auth::Slug.new('first', 'second')
+Mumukit::Auth::Slug.from_options(first: 'hello', second: 'world')
+Mumukit::Auth::Slug.from_options(organization: 'hello', repository: 'world')
+Mumukit::Auth::Slug::Normalized.from_options(organization: 'Hello', repository: 'World!') # answers the slug hello/world
 
-Mumukit::Auth:Slug.join('first', 'second')
-Mumukit::Auth:Slug.join(first: 'first', second: 'second')
-Mumukit::Auth:Slug.join('first') # answers the slug 'first/_'
+Mumukit::Auth::Slug.join('first', 'second')
+Mumukit::Auth::Slug.join(first: 'first', second: 'second')
+Mumukit::Auth::Slug.join('first') # answers the slug 'first/_'
+Mumukit::Auth::Slug::Normalized.join(first: 'fïrst', second: 'sécond') # answers the slug first/second
 
-Mumukit::Auth:Slug.join_s('first', 'second') # answers the string 'first/second'
-Mumukit::Auth:Slug.join_s('first') # answers the string 'first/_'
+Mumukit::Auth::Slug.join_s('first', 'second') # answers the string 'first/second'
+Mumukit::Auth::Slug.join_s('first') # answers the string 'first/_'
+Mumukit::Auth::Slug::Normalized.join_s('FIRST', 'Second') # answers the string 'first/second'
 
 # Parsing
-Mumukit::Auth:Slug.parse("hello/world")
+Mumukit::Auth::Slug.parse("hello/world")
 
 # Convertion from and to string
 "hello/world".to_mumukit_slug
-Mumukit::Auth:Slug.new('foo', 'bar').to_s
+Mumukit::Auth::Slug.new('foo', 'bar').to_s
 
 # Comparing
-"hello/world".to_mumukit_slug == "hello/world".to_mumukit_slug
+"hello/world".to_mumukit_slug == "hello/world".to_mumukit_slug # true
+"Hello/World!".to_mumukit_slug == "hello/world".to_mumukit_slug # true
+"Hello/World!".to_mumukit_slug.eql? "hello/world".to_mumukit_slug # false
+"Hello/World!".to_mumukit_slug.normalize.eql? "hello/world".to_mumukit_slug # true
 
 # Matching
 "hello/world".to_mumukit_slug.match_first 'hello'
@@ -205,5 +211,3 @@ Mumukit::Token.decode encoded_token, Mumukit::Auth:Client.new(client: :custom_cl
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-
-

--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -26,7 +26,7 @@ class Mumukit::Auth::Permissions
   end
 
   def empty?
-    scopes.all? {|_, it| it.empty? }
+    scopes.all? { |_, it| it.empty? }
   end
 
   def compact!

--- a/lib/mumukit/auth/slug.rb
+++ b/lib/mumukit/auth/slug.rb
@@ -35,11 +35,11 @@ module Mumukit::Auth
     end
 
     def ==(o)
-      self.class == o.class && self.normalize.eql?(o.normalize)
+      o.is_a?(Mumukit::Auth::Slug) && self.normalize.eql?(o.normalize)
     end
 
     def eql?(o)
-      self.class == o.class && to_s == o.to_s
+      o.is_a?(Mumukit::Auth::Slug) && to_s == o.to_s
     end
 
     def hash
@@ -57,7 +57,15 @@ module Mumukit::Auth
     end
 
     def normalize
-      dup.normalize!
+      Normalized.new(first, second)
+    end
+
+    def normalized_s
+      normalize.to_s
+    end
+
+    def normalized?
+      normalize.eql? self
     end
 
     def inspect
@@ -99,7 +107,7 @@ module Mumukit::Auth
     end
 
     def self.normalize(first, second)
-      new(first, second).normalize!
+      Normalized.new(first, second)
     end
 
     private
@@ -117,11 +125,29 @@ module Mumukit::Auth
         raise Mumukit::Auth::InvalidSlugFormatError, "Invalid slug: #{slug}. It must be in first/second format"
       end
     end
+
+    class Normalized < Slug
+      alias_method :_normalize!, :normalize!
+
+      def initialize(*)
+        super
+        _normalize!
+      end
+
+      def normalize
+        self
+      end
+
+      def normalize!
+        self
+      end
+
+      def normalized?
+        true
+      end
+    end
   end
 
   class InvalidSlugFormatError < StandardError
   end
 end
-
-
-

--- a/spec/mumukit/slug_spec.rb
+++ b/spec/mumukit/slug_spec.rb
@@ -2,8 +2,20 @@ require 'spec_helper'
 
 describe Mumukit::Auth::Slug do
   it { expect('Foo/Baz'.to_mumukit_slug.normalize).to eql  'foo/baz'.to_mumukit_slug }
+  it { expect('foo/baz'.to_mumukit_slug).to eql  'Foo/Baz'.to_mumukit_slug.normalize }
+  it { expect('Foo/Baz'.to_mumukit_slug.normalize).to eql  'Foo/Baz'.to_mumukit_slug.normalize }
+
+  it { expect('foo/bar-baz'.to_mumukit_slug).to be_normalized }
+  it { expect('FOO/BAR-Baz'.to_mumukit_slug.normalize).to be_normalized }
+
+  it { expect('Foo/bar-baz'.to_mumukit_slug).to_not be_normalized }
+  it { expect('foo/bär-baz'.to_mumukit_slug).to_not be_normalized }
+  it { expect('foo/bar baz'.to_mumukit_slug).to_not be_normalized }
+
   it { expect('foo/bar--baz'.to_mumukit_slug.normalize).to eql  'foo/bar-baz'.to_mumukit_slug }
   it { expect('ein Bär/in München'.to_mumukit_slug.normalize).to eql  'ein-bar/in-munchen'.to_mumukit_slug }
+
+  it { expect('Foo/Baz'.to_mumukit_slug.normalized_s).to eq  'foo/baz' }
 
   it { expect('foo/baz'.to_mumukit_slug).to eq  'foo/baz'.to_mumukit_slug }
   it { expect('FOO/BAZ'.to_mumukit_slug).to eq  'foo/baz'.to_mumukit_slug }
@@ -25,6 +37,7 @@ describe Mumukit::Auth::Slug do
   it { expect(Mumukit::Auth::Slug.new('foo', 'bar').to_s).to eq 'foo/bar' }
   it { expect(Mumukit::Auth::Slug.parse('foo/bar').to_s).to eq 'foo/bar' }
   it { expect(Mumukit::Auth::Slug.join('foo', 'bar').to_s).to eq 'foo/bar' }
+  it { expect(Mumukit::Auth::Slug::Normalized.join('Foo bar', 'baz').to_s).to eq 'foo-bar/baz' }
   it { expect(Mumukit::Auth::Slug.join('foo').to_s).to eq 'foo/_' }
   it { expect(Mumukit::Auth::Slug.join.to_s).to eq '_/_' }
 
@@ -35,6 +48,7 @@ describe Mumukit::Auth::Slug do
   it { expect(Mumukit::Auth::Slug.join_s(organization: 'foo', repository: 'bar')).to eq 'foo/bar' }
   it { expect(Mumukit::Auth::Slug.join_s(first: 'foo', second: 'bar')).to eq 'foo/bar' }
   it { expect(Mumukit::Auth::Slug.join_s(organization: 'foo', course: 'bar')).to eq 'foo/bar' }
+  it { expect(Mumukit::Auth::Slug::Normalized.join_s(organization: 'Foo', course: 'bär')).to eq 'foo/bar' }
 
   it { expect { Mumukit::Auth::Slug.join('foo', 'bar', 'baz') }.to raise_error 'Slugs must have up to two parts' }
   it { expect { Mumukit::Auth::Slug.parse('baz') }.to raise_error 'Invalid slug: baz. It must be in first/second format' }


### PR DESCRIPTION
# :dart: Goal

To offer better methods for dealing with unnormalized slugs

# :memo: Details

The slug normalization concept was introduced in 2019, but it was undocumented. Moreover, although it was used at core method like `==`, it was not possible to check for normalization nor to combine it with other methods easily. 

This PR adds the `normalized?` and `normalized_s` methods, plus the `Normalized` subclass which optimizes a few scenarios and allows to combine normalization with other factory-like class methods.   