### PR TITLE
Feature finer grained tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Tokens are easy-to-use JWT tokens.
 
 ```ruby
 # Creating
+Mumukit::Auth::Token.build uid, expiration: 5.minutes.from_now, metadata: {key: value}
 Mumukit::Auth::Token.new metadata: {key: value}, iss: '...', aud: '...'
 Mumukit::Auth::Token.new {...},
                          Mumukit::Auth::Client.new client: :myclient # use a custom client, see above
@@ -173,8 +174,8 @@ Mumukit::Auth::Token.decode('eyJh...XVCJ9.eA....X0.yRQ..Xw')
 Mumukit::Auth::Token.decode_header('bearer eyJh...XVCJ9.eA....X0.yRQ..Xw')
 
 # Encoding
-Mumukit::Auth::Token.encode(metadata: {key: value}) # answers a jwt **string**
 a_token.encode # answers a jwt **string**
+a_token.encode_header # answers a bearer header **string**
 
 # Verification
 a_token.verify_client!
@@ -202,7 +203,7 @@ Mumukit::Auth.configure do |config|
    config.clients.custom_client_2 = {id: '...', secret: '...'}
 end
 #...and then use them
-Mumukit::Token.encode uid, metadata, Mumukit::Auth:Client.new(client: :custom_client_1)
+Mumukit::Token.build(uid, Mumukit::Auth:Client.new(client: :custom_client_1)).encode
 Mumukit::Token.decode encoded_token, Mumukit::Auth:Client.new(client: :custom_client_2)
 
 ```

--- a/lib/mumukit/auth/token.rb
+++ b/lib/mumukit/auth/token.rb
@@ -2,7 +2,7 @@ module Mumukit::Auth
   class Token
     attr_reader :jwt, :client
 
-    def initialize(jwt, client)
+    def initialize(jwt={}, client = Mumukit::Auth::Client.new)
       @jwt = jwt
       @client = client
     end
@@ -68,7 +68,7 @@ module Mumukit::Auth
       header.split(' ').last
     end
 
-    def self.build(uid, client=Mumukit::Auth::Client.new,
+    def self.build(uid, client = Mumukit::Auth::Client.new,
                    expiration: nil, organization: nil,
                    subject_id: nil, subject_type: nil,
                    metadata: {})
@@ -85,10 +85,8 @@ module Mumukit::Auth
     end
 
     def self.load(encoded)
-      if encoded.nil?
-        nil
-      else
-        decode encoded
+      if encoded.present?
+        decode encoded rescue nil
       end
     end
 

--- a/lib/mumukit/auth/token.rb
+++ b/lib/mumukit/auth/token.rb
@@ -2,7 +2,7 @@ module Mumukit::Auth
   class Token
     attr_reader :jwt, :client
 
-    def initialize(jwt={}, client = Mumukit::Auth::Client.new)
+    def initialize(jwt = {}, client = Mumukit::Auth::Client.new)
       @jwt = jwt
       @client = client
     end

--- a/lib/mumukit/auth/token.rb
+++ b/lib/mumukit/auth/token.rb
@@ -15,6 +15,22 @@ module Mumukit::Auth
       @uid ||= jwt['uid'] || jwt['email'] || jwt['sub']
     end
 
+    def organization
+      @organization ||= jwt['org']
+    end
+
+    def expiration
+      @expiration ||= Time.at jwt['exp']
+    end
+
+    def subject_id
+      @subject_id ||= jwt['sbid']
+    end
+
+    def subject_type
+      @subject_type ||= jwt['sbt']
+    end
+
     def verify_client!
       raise Mumukit::Auth::InvalidTokenError.new('aud mismatch') if client.id != jwt['aud']
     end
@@ -23,12 +39,13 @@ module Mumukit::Auth
       client.encode jwt
     end
 
-    def self.from_rack_env(env)
-      new(env.dig('omniauth.auth', 'extra', 'raw_info') || {})
+    def encode_header
+      'Bearer ' + encode
     end
 
     def self.encode(uid, metadata, client = Mumukit::Auth::Client.new)
-      new({aud: client.id, metadata: metadata, uid: uid}, client).encode
+      warn "Deprecated: please use build and then encode"
+      build(uid, client, metadata: metadata).encode
     end
 
     def self.decode(encoded, client = Mumukit::Auth::Client.new)
@@ -38,7 +55,8 @@ module Mumukit::Auth
     end
 
     def self.encode_header(uid, metadata)
-      'Bearer ' + encode(uid, metadata)
+      warn "Deprecated: please use build and then encode_header"
+      'Bearer ' + build(uid, metadata: metadata).encode_header
     end
 
     def self.decode_header(header, client = Mumukit::Auth::Client.new)
@@ -50,6 +68,32 @@ module Mumukit::Auth
       header.split(' ').last
     end
 
+    def self.build(uid, client=Mumukit::Auth::Client.new,
+                   expiration: nil, organization: nil,
+                   subject_id: nil, subject_type: nil,
+                   metadata: {})
+      new({
+          'uid' => uid,
+          'aud' => client.id,
+          'exp' => expiration&.to_i,
+          'org' => organization,
+          'metadata' => metadata,
+          'sbid' => subject_id,
+          'sbt' => subject_type
+        }.compact,
+        client)
+    end
+
+    def self.load(encoded)
+      if encoded.nil?
+        nil
+      else
+        decode encoded
+      end
+    end
+
+    def self.dump(decoded)
+      decoded.encode
+    end
   end
 end
-

--- a/spec/mumukit/token_spec.rb
+++ b/spec/mumukit/token_spec.rb
@@ -84,4 +84,16 @@ describe Mumukit::Auth::Token do
       it { expect(token.metadata).to eq({}) }
     end
   end
+
+  describe 'serialization' do
+    let(:token) { Mumukit::Auth::Token.build 'mary@example.com' }
+    let(:expired_token) { Mumukit::Auth::Token.build 'mary@example.com', expiration: 1.day.ago }
+
+    it("can create empty, replicable token") {  expect(Mumukit::Auth::Token.new.encode).to eq Mumukit::Auth::Token.new.encode }
+
+    it { expect(Mumukit::Auth::Token.load(token.encode).jwt).to eq token.jwt  }
+    it { expect(Mumukit::Auth::Token.load(expired_token.encode)).to be nil  }
+
+    it { expect(Mumukit::Auth::Token.dump token).to eq token.encode  }
+  end
 end

--- a/spec/mumukit/token_spec.rb
+++ b/spec/mumukit/token_spec.rb
@@ -36,9 +36,9 @@ describe Mumukit::Auth::Token do
     end
 
     context 'not expired' do
-      let(:expiration) { 5.minutes.from_now }
+      let(:expiration) { 5.minutes.from_now.round }
 
-      it { expect(token.expiration.inspect).to eq expiration.inspect }
+      it { expect(token.expiration).to eq expiration }
       it { expect(token.organization).to eq 'central' }
       it { expect(token.subject_type).to eq 'exercise' }
       it { expect(token.subject_id).to eq 485 }
@@ -52,13 +52,13 @@ describe Mumukit::Auth::Token do
                                               "uid"=>"foo@bar.com"
       end
 
-      it { expect(Mumukit::Auth::Token.decode(token.encode).expiration.inspect).to eq expiration.inspect }
+      it { expect(Mumukit::Auth::Token.decode(token.encode).expiration).to eq expiration }
       it { expect(token.encode).to start_with 'ey' }
 
     end
 
     context 'expired' do
-      let(:expiration) { 5.minutes.ago }
+      let(:expiration) { 5.minutes.ago.round }
 
       it { expect(token.encode).to start_with 'ey' }
       it { expect { Mumukit::Auth::Token.decode token.encode }.to raise_error 'Signature has expired' }
@@ -87,7 +87,7 @@ describe Mumukit::Auth::Token do
 
   describe 'serialization' do
     let(:token) { Mumukit::Auth::Token.build 'mary@example.com' }
-    let(:expired_token) { Mumukit::Auth::Token.build 'mary@example.com', expiration: 1.day.ago }
+    let(:expired_token) { Mumukit::Auth::Token.build 'mary@example.com', expiration: 1.day.ago.round }
 
     it("can create empty, replicable token") {  expect(Mumukit::Auth::Token.new.encode).to eq Mumukit::Auth::Token.new.encode }
 


### PR DESCRIPTION
# :dart: Goal

To support extended claims for tokens - `organization`, `subject`, and `expiration`

# :memo: Details

Expiration claim is handled automatically, since it is part of JWT format. `subject` - spitted into `subject_id` and `subject_type` and `organization` are only stored in the token, but its validation goes beyond this PR. 

This PR also makes `Token`s serializable and removes `from_rack_env` deprecated method.