### PR TITLE
Feature manager role

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,11 @@ a_grant.to_s
 
 ### Roles
 
+![roles hierarchy](https://yuml.me/diagram/plain/class/[Student]^-[ExStudent],[Teacher]^-[Student],[Headmaster]^-[Teacher],[Janitor]^-[Headmaster],[Editor]^-[Writer],[Manager]^-[Editor],[Manager]^-[Janitor],[Supervisor]^-[Moderator],[Supervisor]^-[Manager],[Admin]^-[Supervisor],[Owner]^-[Admin]).
+
+
 ```ruby
-Mumukit::Auth::Roles.ROLES # answers [:student, :teacher, :headmaster, :writer, :editor, :janitor, :admin, :owner]
+Mumukit::Auth::Roles.ROLES # answers [:ex_student, :student, :teacher, :headmaster, :writer, :editor, :janitor, :moderator, :supervisor, :manager, :admin, :owner]
 ```
 
 ### Permissions

--- a/lib/mumukit/auth/permissions.rb
+++ b/lib/mumukit/auth/permissions.rb
@@ -5,7 +5,7 @@ class Mumukit::Auth::Permissions
   attr_accessor :scopes
 
   def initialize(scopes={})
-    @scopes = {}.with_indifferent_access
+    clear!
     add_scopes! scopes
   end
 
@@ -130,6 +130,10 @@ class Mumukit::Auth::Permissions
 
   def protect_permissions_assignment!(other, previous)
     raise Mumukit::Auth::UnauthorizedAccessError unless assign_to?(self.class.reparse(other), previous)
+  end
+
+  def clear!
+    @scopes = {}.with_indifferent_access
   end
 
   def as_set

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -81,10 +81,10 @@ module Mumukit::Auth
     class Moderator < Role
       parent :supervisor
     end
-    class Supervisor < Role
-      parent :manager
-    end
     class Manager < Role
+      parent :supervisor
+    end
+    class Supervisor < Role
       parent :admin
     end
     class Admin < Role

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -73,15 +73,18 @@ module Mumukit::Auth
       parent :editor
     end
     class Editor < Role
-      parent :admin
+      parent :manager
     end
     class Janitor < Role
-      parent :admin
+      parent :manager
     end
     class Moderator < Role
       parent :forum_supervisor
     end
     class ForumSupervisor < Role
+      parent :manager
+    end
+    class Manager < Role
       parent :admin
     end
     class Admin < Role

--- a/lib/mumukit/auth/role.rb
+++ b/lib/mumukit/auth/role.rb
@@ -79,9 +79,9 @@ module Mumukit::Auth
       parent :manager
     end
     class Moderator < Role
-      parent :forum_supervisor
+      parent :supervisor
     end
-    class ForumSupervisor < Role
+    class Supervisor < Role
       parent :manager
     end
     class Manager < Role

--- a/lib/mumukit/auth/roles.rb
+++ b/lib/mumukit/auth/roles.rb
@@ -1,7 +1,7 @@
 module Mumukit::Auth
   module Roles
     ROLES = [:ex_student, :student, :teacher, :headmaster, :writer, :editor, :janitor,
-             :moderator, :forum_supervisor, :manager, :admin, :owner]
+             :moderator, :supervisor, :manager, :admin, :owner]
 
     ROLES.each do |role|
       define_method "#{role}?" do |scope = Mumukit::Auth::Slug.any|

--- a/lib/mumukit/auth/roles.rb
+++ b/lib/mumukit/auth/roles.rb
@@ -1,6 +1,7 @@
 module Mumukit::Auth
   module Roles
-    ROLES = [:ex_student, :student, :teacher, :headmaster, :writer, :editor, :janitor, :moderator, :forum_supervisor, :admin, :owner]
+    ROLES = [:ex_student, :student, :teacher, :headmaster, :writer, :editor, :janitor,
+             :moderator, :forum_supervisor, :manager, :admin, :owner]
 
     ROLES.each do |role|
       define_method "#{role}?" do |scope = Mumukit::Auth::Slug.any|
@@ -9,4 +10,3 @@ module Mumukit::Auth
     end
   end
 end
-

--- a/lib/mumukit/auth/roles.rb
+++ b/lib/mumukit/auth/roles.rb
@@ -1,7 +1,13 @@
 module Mumukit::Auth
   module Roles
-    ROLES = [:ex_student, :student, :teacher, :headmaster, :writer, :editor, :janitor,
-             :moderator, :supervisor, :manager, :admin, :owner]
+    FINE_GRAINED_ROLES = [
+      :ex_student, :student, :teacher, :headmaster, :writer, :editor, :janitor,
+      :moderator, :manager
+    ]
+    COARSE_GRAINED_ROLES = [:supervisor, :admin, :owner]
+
+    ROLES = COARSE_GRAINED_ROLES + FINE_GRAINED_ROLES
+
 
     ROLES.each do |role|
       define_method "#{role}?" do |scope = Mumukit::Auth::Slug.any|

--- a/lib/mumukit/auth/token.rb
+++ b/lib/mumukit/auth/token.rb
@@ -43,20 +43,10 @@ module Mumukit::Auth
       'Bearer ' + encode
     end
 
-    def self.encode(uid, metadata, client = Mumukit::Auth::Client.new)
-      warn "Deprecated: please use build and then encode"
-      build(uid, client, metadata: metadata).encode
-    end
-
     def self.decode(encoded, client = Mumukit::Auth::Client.new)
       new client.decode(encoded), client
     rescue JWT::DecodeError => e
       raise Mumukit::Auth::InvalidTokenError.new(e)
-    end
-
-    def self.encode_header(uid, metadata)
-      warn "Deprecated: please use build and then encode_header"
-      'Bearer ' + build(uid, metadata: metadata).encode_header
     end
 
     def self.decode_header(header, client = Mumukit::Auth::Client.new)

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -136,6 +136,8 @@ describe Mumukit::Auth::Permissions do
       it { expect(permissions.teacher? 'foo/baz').to be true }
       it { expect(permissions.teacher? 'foo/_').to be true }
 
+      it { expect(permissions.manager? 'foo/*').to be false }
+      it { expect(permissions.manager?).to be false }
       it { expect(permissions.admin?).to be false }
       it { expect(permissions.owner?).to be false }
 
@@ -181,6 +183,9 @@ describe Mumukit::Auth::Permissions do
     describe 'owner permissions' do
       let(:permissions) { parse_permissions(owner: '*') }
 
+      it { expect(permissions.manager?).to be true }
+      it { expect(permissions.manager? 'foo/*').to be true }
+      it { expect(permissions.manager? 'foo/_').to be true }
       it { expect(permissions.admin?).to be true }
 
       it { expect(permissions.owner?).to be true }

--- a/spec/mumukit/permissions_spec.rb
+++ b/spec/mumukit/permissions_spec.rb
@@ -404,6 +404,14 @@ describe Mumukit::Auth::Permissions do
     end
   end
 
+  describe 'clear!' do
+    let(:permissions) { parse_permissions(student: '*') }
+
+    before { permissions.clear! }
+
+    it { expect(permissions).to be_empty }
+  end
+
   describe 'remove_permission!' do
     let(:permissions) { parse_permissions(student: 'foo/bar:test/*:foo/baz') }
 

--- a/spec/mumukit/token_spec.rb
+++ b/spec/mumukit/token_spec.rb
@@ -12,12 +12,6 @@ describe Mumukit::Auth::Token do
   end
 
   describe 'decode_header' do
-    context 'with legacy encode_header' do
-      let(:header) { Mumukit::Auth::Token.encode_header('foo@bar.com', foo: 'bar') }
-
-      it { expect(Mumukit::Auth::Token.decode_header(header).metadata).to json_like foo: 'bar' }
-    end
-
     context 'with current encode_header' do
       let(:header) { Mumukit::Auth::Token.build('foo@bar.com', metadata: {foo: 'bar'}).encode_header }
 


### PR DESCRIPTION
# :dart: Goal

To introduce a new permission, called `manager`, for organization self-management. 


# :memo: Details
 
A new manager role has been added. Also, `forum_supervisor` has been renamed to just `supervisor`. Lastly, some deprecated methods were removed. 

# :back: Backward compatibility

This PR is not backwards compatible, since it renames supervisor role. 